### PR TITLE
feat(actions-flow/#17): 블록 편집 UX 개선 및 YAML 생성 로직 고도화 (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,98 @@
-# 프론트 프로젝트 협업 가이드 및 컨벤션
+# PipeMate Frontend Next.js
 
-이 문서는 Next.js 기반 프로젝트의 **협업 규칙**과 개발 컨벤션을 정리한 가이드입니다. 새로운 팀원이 빠르게 프로젝트에 적응하고, 일관된 코드와 효율적인 협업이 이루어질 수 있도록 작성되었습니다.
+GitHub Actions 워크플로우를 시각적으로 구성할 수 있는 프론트엔드 애플리케이션입니다.
 
-## 1. 프로젝트 개요
+## 환경 설정
 
-- **프레임워크**: Next.js (React 기반)
-- **초기화 도구**: [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app) 사용
-- **주요 특징**:
-  - App Router 구조
-  - TypeScript 기반
-  - Tailwind CSS, ESLint 등 추가 도구는 설정에 따라 다를 수 있음
+### 환경변수 설정
 
-## 2. 개발 환경 세팅
-
-### 2.1. 의존성 설치
-
-아래 명령어 중 하나를 사용하여 패키지를 설치하세요.
+프로젝트 루트에 `.env.local` 파일을 생성하고 다음 환경변수들을 설정하세요:
 
 ```bash
+# API 설정
+NEXT_PUBLIC_USE_REAL_API=false
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
+
+# GitHub 설정
+NEXT_PUBLIC_GITHUB_CLIENT_ID=your_github_client_id_here
+GITHUB_CLIENT_SECRET=your_github_client_secret_here
+
+# 기타 설정
+NODE_ENV=development
+PORT=3000
+```
+
+### 환경변수 설명
+
+- `NEXT_PUBLIC_USE_REAL_API`: 실제 백엔드 API 사용 여부
+  - `false`: 목 데이터 사용 (개발용)
+  - `true`: 실제 백엔드 API 사용 (프로덕션용)
+- `NEXT_PUBLIC_API_BASE_URL`: 백엔드 API 기본 URL
+- `NEXT_PUBLIC_GITHUB_CLIENT_ID`: GitHub OAuth App Client ID
+- `GITHUB_CLIENT_SECRET`: GitHub OAuth App Client Secret
+
+## 설치 및 실행
+
+```bash
+# 의존성 설치
 npm install
-# 또는
-yarn install
-# 또는
-pnpm install
-# 또는
-bun install
-```
 
-### 2.2. 개발 서버 실행
-
-```bash
+# 개발 서버 실행
 npm run dev
-# 또는
-yarn dev
-# 또는
-pnpm dev
-# 또는
-bun dev
+
+# 프로덕션 빌드
+npm run build
+
+# 프로덕션 서버 실행
+npm start
 ```
 
-- 개발 서버 기본 주소: [http://localhost:3000](http://localhost:3000)
+## API 사용 방법
 
-## 3. 프로젝트 구조 및 파일 관리
+### 목 데이터 사용 (개발용)
 
-- **메인 페이지**: `app/page.tsx`
-- **컴포넌트/모듈**: 기능별로 `app/components`, `app/modules` 등으로 분리하여 관리합니다.
-- **스타일**: Tailwind CSS 또는 글로벌 스타일 시트(`globals.css`)를 사용합니다.
-- **폰트**: [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts)로 폰트 최적화, 기본 폰트는 [Geist](https://vercel.com/font) 사용
+```typescript
+import { createPipeline, getPipeline } from '@/app/github-actions-flow/constants/mockData';
 
-## 4. 코드 컨벤션
+// 목 데이터로 파이프라인 생성
+const result = await createPipeline({
+  owner: 'donghyuun',
+  repo: 'pipemate',
+  workflowName: 'test-workflow',
+  inputJson: [...],
+  description: '테스트 워크플로우'
+});
+```
 
-- **언어**: TypeScript 권장
-- **코딩 스타일**: Prettier, ESLint 적용 (`.prettierrc`, `eslint.config.mjs` 확인)
-- **폴더/파일명**: camelCase 사용
-- **컴포넌트 명명**: PascalCase 사용
-- **주석**: 함수/컴포넌트 상단에 JSDoc 스타일로 작성(예: API/훅/컨텍스트에 적용)
-- **커밋 메시지**: [Conventional Commits](https://www.conventionalcommits.org/) 규칙 준수
+### 실제 API 사용 (프로덕션용)
 
-## 5. 협업 규칙
+환경변수 `NEXT_PUBLIC_USE_REAL_API=true`로 설정하면 자동으로 실제 백엔드 API를 사용합니다.
 
-- **브랜치 전략**:
-  - `main`: 배포용
-  - `feat/브랜치명`: 기능 개발
-  - Pull Request(PR)로 코드 리뷰 필수
-- **이슈 관리**: GitHub Issues 사용, 작업 시작 전 할당
-- **코드 리뷰**: 최소 1명 이상의 승인 필요
-- **문서화**: 주요 변경사항은 README 또는 별도 문서에 기록
+```typescript
+// 실제 백엔드 API 호출
+const result = await createPipeline({
+  owner: 'donghyuun',
+  repo: 'pipemate',
+  workflowName: 'test-workflow',
+  inputJson: [...],
+  description: '테스트 워크플로우'
+});
+```
 
-## 6. 배포
+## 주요 기능
 
-- **플랫폼**: [Vercel](https://vercel.com/) 권장
-- **배포 방법**: Vercel 연동 또는 수동 배포
-- **참고 문서**: [Next.js 배포 가이드](https://nextjs.org/docs/app/building-your-application/deploying)
+- GitHub Actions 워크플로우 시각적 구성
+- 블록 기반 워크플로우 에디터
+- 프리셋 블록 및 파이프라인 제공
+- YAML 변환 및 GitHub 업로드
+- 실시간 워크플로우 실행 모니터링
 
-## 7. 참고 자료
+## 기술 스택
 
-- [Next.js 공식 문서](https://nextjs.org/docs)
-- [Next.js 튜토리얼](https://nextjs.org/learn)
-- [Next.js GitHub](https://github.com/vercel/next.js)
-
-이 가이드는 프로젝트의 일관성과 효율적인 협업을 위해 지속적으로 업데이트될 수 있습니다. 궁금한 점이나 개선 사항이 있다면 언제든지 팀에 공유해주세요.
+- **Framework**: Next.js 14
+- **Language**: TypeScript
+- **UI Library**: React
+- **Styling**: Tailwind CSS
+- **State Management**: React Context
+- **Flow Editor**: React Flow
+- **HTTP Client**: Fetch API

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "react-dom": "19.1.0",
         "react-toastify": "^11.0.5",
         "tailwind-merge": "^3.3.1",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "yaml": "2.8.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -7363,6 +7364,18 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-dom": "19.1.0",
     "react-toastify": "^11.0.5",
     "tailwind-merge": "^3.3.1",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "yaml": "2.8.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -4,7 +4,7 @@
 
 ## 구조
 
-```
+```text
 src/api/
 ├── index.ts              # 기본 API 클라이언트 설정
 ├── githubClient.ts       # GitHub 전용 클라이언트 (토큰 인터셉터 포함)
@@ -25,21 +25,16 @@ src/api/
 ### 기본 사용법
 
 ```typescript
-import {
-  pipelineAPI,
-  workflowAPI,
-  secretsAPI,
-  blockAPI,
-} from "@/api/githubClient";
+import { pipelineAPI, workflowAPI, secretsAPI, blockAPI } from '@/api';
 
 // 파이프라인 API 사용
-const result = await pipelineAPI.get("workflow-name", "owner", "repo");
+const result = await pipelineAPI.get('workflow-name', 'owner', 'repo');
 
 // 워크플로우 API 사용
-const workflows = await workflowAPI.getList("owner", "repo");
+const workflows = await workflowAPI.getList('owner', 'repo');
 
 // 시크릿 API 사용
-const secrets = await secretsAPI.getList("owner", "repo");
+const secrets = await secretsAPI.getList('owner', 'repo');
 
 // 블록 API 사용
 const blocks = await blockAPI.getAll();
@@ -48,18 +43,14 @@ const blocks = await blockAPI.getAll();
 ### 타입 사용법
 
 ```typescript
-import {
-  PipelineRequest,
-  WorkflowItem,
-  BlockResponse,
-} from "@/api/githubClient";
+import { PipelineRequest, WorkflowItem, BlockResponse } from '@/api';
 
 const request: PipelineRequest = {
-  owner: "username",
-  repo: "repository",
-  workflowName: "workflow.yml",
+  owner: 'username',
+  repo: 'repository',
+  workflowName: 'workflow.yml',
   inputJson: [],
-  description: "설명",
+  description: '설명',
 };
 ```
 

--- a/src/api/blocks/index.ts
+++ b/src/api/blocks/index.ts
@@ -1,4 +1,5 @@
-import githubClient from '@/api/githubClient';
+import { githubClient } from '@/api';
+import { API_ENDPOINTS } from '@/config/apiConfig';
 import { BlockResponse } from '@/api/types';
 
 /**
@@ -6,5 +7,6 @@ import { BlockResponse } from '@/api/types';
  */
 export const blockAPI = {
   // * 4.1 모든 블록 조회
-  getAll: () => githubClient.get<BlockResponse[]>('/api/blocks'),
+  // PresetController에 맞춘 엔드포인트로 변경
+  getAll: () => githubClient.get<BlockResponse[]>(API_ENDPOINTS.PRESETS.BLOCKS),
 };

--- a/src/api/githubClient.ts
+++ b/src/api/githubClient.ts
@@ -6,12 +6,19 @@
 import axios from 'axios';
 import { STORAGES } from '@/config/appConstants';
 import { getCookie } from '@/lib/cookieUtils';
+import { API_CONFIG } from '@/config/apiConfig';
 
 // * GitHub 전용 클라이언트 (GitHub Personal Access Token 포함)
-// - NEXT_PUBLIC_API_URL이 없으면 동일 오리진 상대 경로(리라이트 적용)
+// - 개발(default): 동일 오리진 상대 경로(Next.js rewrite 적용)
+// - 운영/실서비스(또는 강제 플래그): 백엔드 절대 경로 사용
+// - 레거시 호환: NEXT_PUBLIC_API_URL이 있으면 우선 사용
+const githubBaseUrl = API_CONFIG.USE_REAL_API
+  ? process.env.NEXT_PUBLIC_API_URL ?? API_CONFIG.BASE_URL
+  : '';
+
 const githubClient = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL ?? '',
-  timeout: 10000,
+  baseURL: githubBaseUrl,
+  timeout: API_CONFIG.TIMEOUT,
   headers: { 'Content-Type': 'application/json' },
 });
 
@@ -28,17 +35,5 @@ githubClient.interceptors.request.use(
   },
   (error) => Promise.reject(error),
 );
-
-// * API 모듈들 import
-export { pipelineAPI } from './pipeline';
-export { workflowAPI } from './workflow';
-export { secretsAPI } from './secrets';
-export { blockAPI } from './blocks';
-
-// * API Hooks export
-export * from './hooks';
-
-// * 타입들 export
-export * from './types';
 
 export default githubClient;

--- a/src/api/hooks/index.ts
+++ b/src/api/hooks/index.ts
@@ -1,5 +1,6 @@
 // * API Hooks 메인 export 파일
-export * from "./useWorkflows";
-export * from "./usePipeline";
-export * from "./useSecrets";
-export * from "./useBlocks";
+export * from './useWorkflows';
+export * from './usePipeline';
+export * from './useSecrets';
+export * from './useBlocks';
+export * from './usePresets';

--- a/src/api/hooks/useBlocks.ts
+++ b/src/api/hooks/useBlocks.ts
@@ -2,7 +2,7 @@
  * 블록 관련 React Query 훅
  */
 import { useQuery } from '@tanstack/react-query';
-import { blockAPI } from '@/api/githubClient';
+import { blockAPI } from '@/api/blocks';
 
 // * 모든 블록 조회
 export const useBlocks = () => {

--- a/src/api/hooks/usePipeline.ts
+++ b/src/api/hooks/usePipeline.ts
@@ -3,7 +3,7 @@
  * - 조회/생성/수정/삭제 뮤테이션을 제공합니다.
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { pipelineAPI } from '@/api/githubClient';
+import { pipelineAPI } from '@/api';
 
 // * 파이프라인 조회
 export const usePipeline = (ymlFileName: string, owner: string, repo: string) => {

--- a/src/api/hooks/usePresets.ts
+++ b/src/api/hooks/usePresets.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { presetsAPI } from '@/api/presets';
+import { BlockResponse, PipelineResponse } from '@/api/types';
+
+// 프리셋 블록/파이프라인 React Query 훅
+export const usePresetBlocks = () =>
+  useQuery({
+    queryKey: ['preset-blocks'],
+    queryFn: async () => {
+      const res = await presetsAPI.getBlocks();
+      return res.data as BlockResponse[];
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+export const usePresetPipelines = () =>
+  useQuery({
+    queryKey: ['preset-pipelines'],
+    queryFn: async () => {
+      const res = await presetsAPI.getPipelines();
+      return res.data as PipelineResponse[];
+    },
+    staleTime: 5 * 60 * 1000,
+  });

--- a/src/api/hooks/useSecrets.ts
+++ b/src/api/hooks/useSecrets.ts
@@ -2,7 +2,7 @@
  * GitHub Secrets 관련 React Query 훅 모음
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { secretsAPI } from '@/api/githubClient';
+import { secretsAPI } from '@/api';
 import { GithubSecretRequest } from '@/api/types';
 
 // * Secrets 목록 조회

--- a/src/api/hooks/useWorkflows.ts
+++ b/src/api/hooks/useWorkflows.ts
@@ -3,7 +3,7 @@
  * - 목록/실행/로그/잡/실행/취소를 제공합니다.
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { workflowAPI } from '@/api/githubClient';
+import { workflowAPI } from '@/api';
 
 // * 워크플로우 목록 조회
 export const useWorkflows = (owner: string, repo: string) => {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,19 +1,35 @@
 /**
  * API 기본 클라이언트
  * - 앱 전역에서 공통으로 사용하는 axios 인스턴스를 정의합니다.
- * - baseURL은 `NEXT_PUBLIC_API_URL`이 설정되지 않으면 동일 오리진을 사용합니다.
+ * - baseURL은 환경과 설정에 따라 `apiConfig`를 우선 활용합니다.
  */
 import axios from 'axios';
+import { API_CONFIG } from '@/config/apiConfig';
 
 // * 기본 API 클라이언트 설정
-// - NEXT_PUBLIC_API_URL이 설정되지 않은 경우 동일 오리진 상대 경로(리라이트 적용)로 호출
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+// - 개발(default): 동일 오리진 상대 경로(Next.js rewrite 적용)
+// - 운영/실서비스(또는 강제 플래그): 백엔드 절대 경로 사용
+// - 레거시 호환: NEXT_PUBLIC_API_URL이 있으면 우선 사용
+const BASE_URL = API_CONFIG.USE_REAL_API
+  ? process.env.NEXT_PUBLIC_API_URL ?? API_CONFIG.BASE_URL
+  : '';
 
 // * 기본 axios 인스턴스 (인터셉터 없음)
 const apiClient = axios.create({
   baseURL: BASE_URL,
-  timeout: 10000, // 10초로 증가
+  timeout: API_CONFIG.TIMEOUT,
   headers: { 'Content-Type': 'application/json' },
 });
 
 export default apiClient;
+
+// * API 배럴 export
+export { default as githubClient } from './githubClient';
+export { pipelineAPI } from './pipeline';
+export { workflowAPI } from './workflow';
+export { secretsAPI } from './secrets';
+export { blockAPI } from './blocks';
+
+// * Hooks, Types 재노출
+export * from './hooks';
+export * from './types';

--- a/src/api/pipeline/index.ts
+++ b/src/api/pipeline/index.ts
@@ -1,4 +1,5 @@
-import githubClient from '@/api/githubClient';
+import { githubClient } from '@/api';
+import { API_ENDPOINTS } from '@/config/apiConfig';
 import { PipelineRequest, PipelineResponse } from '@/api/types';
 import { removeYmlExtension } from '@/lib/utils';
 import { ServerBlock } from '@/app/github-actions-flow/types';
@@ -19,7 +20,7 @@ export const pipelineAPI = {
       ...data,
       workflowName: removeYmlExtension(data.workflowName),
     };
-    return githubClient.post<string>('/api/pipelines', processedData);
+    return githubClient.post<string>(API_ENDPOINTS.PIPELINES.CREATE, processedData);
   },
 
   // * 1.2 파이프라인 조회
@@ -31,10 +32,7 @@ export const pipelineAPI = {
    */
   get: (ymlFileName: string, owner: string, repo: string) =>
     githubClient.get<PipelineResponse>(
-      `/api/pipelines/${removeYmlExtension(ymlFileName)}`,
-      {
-        params: { owner, repo },
-      },
+      API_ENDPOINTS.PIPELINES.GET(removeYmlExtension(ymlFileName), owner, repo),
     ),
 
   // * 1.3 파이프라인 업데이트
@@ -48,7 +46,10 @@ export const pipelineAPI = {
       ...data,
       workflowName: removeYmlExtension(data.workflowName),
     };
-    return githubClient.put<PipelineResponse>('/api/pipelines', processedData);
+    return githubClient.put<PipelineResponse>(
+      API_ENDPOINTS.PIPELINES.UPDATE,
+      processedData,
+    );
   },
 
   // * 1.4 파이프라인 삭제
@@ -59,9 +60,9 @@ export const pipelineAPI = {
    * @param repo GitHub 리포지토리
    */
   delete: (ymlFileName: string, owner: string, repo: string) =>
-    githubClient.delete(`/api/pipelines/${removeYmlExtension(ymlFileName)}`, {
-      params: { owner, repo },
-    }),
+    githubClient.delete(
+      API_ENDPOINTS.PIPELINES.DELETE(removeYmlExtension(ymlFileName), owner, repo),
+    ),
 
   // * 1.5 워크플로우 저장 (ServerBlock 배열을 받아서 저장)
   /**
@@ -81,6 +82,6 @@ export const pipelineAPI = {
       inputJson: data.blocks,
       description: data.description,
     };
-    return githubClient.post<string>('/api/pipelines', processedData);
+    return githubClient.post<string>(API_ENDPOINTS.PIPELINES.CREATE, processedData);
   },
 };

--- a/src/api/presets/index.ts
+++ b/src/api/presets/index.ts
@@ -1,0 +1,16 @@
+import { githubClient } from '@/api';
+import { API_ENDPOINTS } from '@/config/apiConfig';
+import { PipelineResponse, BlockResponse } from '@/api/types';
+
+/**
+ * Presets API
+ * - 프리셋 파이프라인/블록 조회 전용
+ */
+export const presetsAPI = {
+  // 프리셋 파이프라인 목록 조회
+  getPipelines: () =>
+    githubClient.get<PipelineResponse[]>(API_ENDPOINTS.PRESETS.PIPELINES),
+
+  // 프리셋 블록 목록 조회 (기존 blockAPI와 중복되지만, 일관성을 위해 제공)
+  getBlocks: () => githubClient.get<BlockResponse[]>(API_ENDPOINTS.PRESETS.BLOCKS),
+};

--- a/src/api/secrets/index.ts
+++ b/src/api/secrets/index.ts
@@ -1,4 +1,5 @@
-import githubClient from '@/api/githubClient';
+import { githubClient } from '@/api';
+import { API_ENDPOINTS } from '@/config/apiConfig';
 import {
   GithubSecretListResponse,
   GroupedGithubSecretListResponse,
@@ -13,15 +14,13 @@ import {
 export const secretsAPI = {
   // * 2.1 Secrets 목록 조회 (기본)
   getList: (owner: string, repo: string) =>
-    githubClient.get<GithubSecretListResponse>('/api/github/repos/secrets', {
-      params: { owner, repo },
-    }),
+    githubClient.get<GithubSecretListResponse>(API_ENDPOINTS.GITHUB.SECRETS(owner, repo)),
 
   // * 2.2 Secrets 그룹화된 목록 조회 (새로 추가)
   getGroupedList: (owner: string, repo: string) =>
-    githubClient.get<GroupedGithubSecretListResponse>('/api/github/repos/secrets', {
-      params: { owner, repo },
-    }),
+    githubClient.get<GroupedGithubSecretListResponse>(
+      API_ENDPOINTS.GITHUB.SECRETS(owner, repo),
+    ),
 
   // * 2.3 Secret 생성/수정
   createOrUpdate: (

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -85,9 +85,15 @@ export interface GroupedGithubSecretListResponse {
 export interface BlockResponse {
   id: number;
   name: string;
-  type: string;
+  type: 'trigger' | 'job' | 'step';
   description?: string;
-  content: Record<string, unknown>;
-  createdAt: string;
-  updatedAt: string;
+  // 백엔드 BlockResponse 표준 필드
+  config: Record<string, unknown>;
+  jobName?: string; // job/step에서만
+  domain?: string; // step에서만
+  task?: string[]; // step에서만
+  // 과거/목 데이터 호환 필드 (있을 수도 있음)
+  content?: Record<string, unknown>;
+  createdAt?: string;
+  updatedAt?: string;
 }

--- a/src/api/workflow/index.ts
+++ b/src/api/workflow/index.ts
@@ -1,4 +1,5 @@
-import githubClient from '@/api/githubClient';
+import { githubClient } from '@/api';
+import { API_ENDPOINTS } from '@/config/apiConfig';
 import { WorkflowItem, GithubJobDetailResponse } from '@/api/types';
 
 /**
@@ -8,21 +9,19 @@ import { WorkflowItem, GithubJobDetailResponse } from '@/api/types';
 export const workflowAPI = {
   // * 3.1 Workflow 목록 조회
   getList: (owner: string, repo: string) =>
-    githubClient.get<{ workflows: WorkflowItem[] }>('/api/github/workflows', {
-      params: { owner, repo },
-    }),
+    githubClient.get<{ workflows: WorkflowItem[] }>(
+      API_ENDPOINTS.GITHUB.WORKFLOWS(owner, repo),
+    ),
 
   // * 3.2 Workflow 상세 정보 조회
   getDetail: (workflowId: string, owner: string, repo: string) =>
-    githubClient.get<WorkflowItem>(`/api/github/workflows/${workflowId}`, {
-      params: { owner, repo },
-    }),
+    githubClient.get<WorkflowItem>(
+      API_ENDPOINTS.GITHUB.WORKFLOW_DETAIL(workflowId, owner, repo),
+    ),
 
   // * 3.3 Workflow 실행 목록 조회
   getRuns: (owner: string, repo: string) =>
-    githubClient.get('/api/github/workflow-runs', {
-      params: { owner, repo },
-    }),
+    githubClient.get(API_ENDPOINTS.GITHUB.WORKFLOW_RUNS(owner, repo)),
 
   // * 3.4 Workflow 실행 상세 정보 조회
   getRunDetail: (owner: string, repo: string, runId: string) =>
@@ -32,7 +31,7 @@ export const workflowAPI = {
 
   // * 3.5 Workflow 실행 로그 조회
   getRunLogs: (owner: string, repo: string, runId: string) =>
-    githubClient.get<string>('/api/github/workflow-run/logs/raw', {
+    githubClient.get<string>(`/api/github/workflow-run/logs/raw`, {
       params: { owner, repo, runId },
     }),
 

--- a/src/app/github-actions-flow/constants/mockData.ts
+++ b/src/app/github-actions-flow/constants/mockData.ts
@@ -4,7 +4,49 @@
 //* 백엔드 서버에서 받아올 프리셋 블록 데이터의 목 데이터
 //* 나중에 API 호출로 대체될 예정
 
-import { ServerBlock, Pipeline } from "../types";
+import { ServerBlock, Pipeline } from '../types';
+import { API_CONFIG, API_ENDPOINTS, getErrorMessage } from '../../../config/apiConfig';
+
+//* 백엔드 API와 일치하는 타입 정의
+export interface BlockConfig {
+  name?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, any>;
+  'runs-on'?: string;
+  on?: Record<string, any>;
+  [key: string]: any;
+}
+
+//* 백엔드 BlockResponse와 일치하는 타입
+export interface BlockData {
+  id?: number;
+  name: string;
+  type: 'trigger' | 'job' | 'step';
+  description: string;
+  config: BlockConfig;
+  jobName?: string; // 백엔드에서는 jobName으로 사용
+  domain?: string;
+  task?: string[];
+}
+
+//* 백엔드 PipelineRequest와 일치하는 타입
+export interface WorkflowRequest {
+  owner: string;
+  repo: string;
+  workflowName: string;
+  inputJson: BlockData[];
+  description?: string;
+}
+
+//* 백엔드 PipelineResponse와 일치하는 타입
+export interface WorkflowResponse {
+  workflowId: string;
+  workflowName: string;
+  originalJson: BlockData[];
+  success: boolean;
+  message: string;
+}
 
 //* 프리셋 블록 데이터 타입 (백엔드 API 응답과 동일한 구조)
 export interface PresetBlock extends ServerBlock {
@@ -16,22 +58,20 @@ export interface PresetPipeline extends Pipeline {
   id: string; //* 고유 식별자
 }
 
-//* 탭별 프리셋 블록 데이터
-export const PRESET_BLOCKS: Record<string, PresetBlock[]> = {
+//* 탭별 프리셋 블록 데이터 (새로운 구조)
+export const PRESET_BLOCKS: Record<string, BlockData[]> = {
   //* 트리거 탭 - 워크플로우 트리거 설정 블록
   trigger: [
     {
-      id: "trigger-workflow-basic",
-      name: "워크플로우 기본 설정",
-      type: "trigger",
-      description:
-        "GitHub Actions 워크플로우 이름과 트리거 조건을 설정하는 블록입니다.",
+      name: '워크플로우 기본 설정',
+      type: 'trigger',
+      description: 'GitHub Actions 워크플로우 이름과 트리거 조건을 설정하는 블록입니다.',
       config: {
-        name: "Java CICD",
+        name: 'Java CICD',
         on: {
           workflow_dispatch: {},
           push: {
-            branches: ["v2"],
+            branches: ['v2'],
           },
         },
       },
@@ -41,17 +81,12 @@ export const PRESET_BLOCKS: Record<string, PresetBlock[]> = {
   //* Job 탭 - Job 설정 블록
   job: [
     {
-      id: "job-basic",
-      name: "Job 설정",
-      type: "job",
-      description: "사용자 정의 job-id와 실행 환경을 설정하는 블록입니다.",
-      "job-name": "job1",
+      name: 'Job 설정',
+      type: 'job',
+      jobName: 'job1',
+      description: '사용자 정의 job-id와 실행 환경을 설정하는 블록입니다.',
       config: {
-        jobs: {
-          job1: {
-            "runs-on": "ubuntu-latest",
-          },
-        },
+        'runs-on': 'ubuntu-latest',
       },
     },
   ],
@@ -59,122 +94,285 @@ export const PRESET_BLOCKS: Record<string, PresetBlock[]> = {
   //* Step 탭 - 다양한 Step 블록들
   step: [
     {
-      id: "step-checkout",
-      name: "Checkout repository",
-      type: "step",
-      domain: "github",
-      task: ["checkout"],
-      description: "GitHub 저장소를 체크아웃하는 단계입니다.",
-      "job-name": "job1",
+      name: 'Checkout repository',
+      type: 'step',
+      domain: 'github',
+      task: ['checkout'],
+      description: 'GitHub 저장소를 체크아웃하는 단계입니다.',
+      jobName: 'job1',
       config: {
-        name: "Checkout repository",
-        uses: "actions/checkout@v4",
+        name: 'Checkout repository',
+        uses: 'actions/checkout@v4',
       },
     },
     {
-      id: "step-java-setup",
-      name: "Set up JDK 21",
-      type: "step",
-      domain: "java",
-      task: ["setup"],
-      description:
-        "GitHub Actions 실행 환경에 AdoptOpenJDK 21을 설치하는 단계입니다.",
-      "job-name": "job1",
+      name: 'Set up JDK 21',
+      type: 'step',
+      domain: 'java',
+      task: ['setup'],
+      description: 'GitHub Actions 실행 환경에 AdoptOpenJDK 21을 설치하는 단계입니다.',
+      jobName: 'job1',
       config: {
-        name: "Set up JDK 21",
-        uses: "actions/setup-java@v4",
+        name: 'Set up JDK 21',
+        uses: 'actions/setup-java@v4',
         with: {
-          distribution: "adopt",
-          "java-version": "21",
+          distribution: 'adopt',
+          'java-version': '21',
         },
       },
     },
     {
-      id: "step-gradle-build",
-      name: "Gradle 빌드 블록",
-      type: "step",
-      domain: "gradle",
-      task: ["build"],
-      description:
-        "Gradle Wrapper에 권한을 부여하고, 테스트를 제외한 빌드만 수행합니다.",
-      "job-name": "job1",
+      name: 'Gradle 빌드 블록',
+      type: 'step',
+      domain: 'gradle',
+      task: ['build'],
+      description: 'Gradle Wrapper에 권한을 부여하고, 테스트를 제외한 빌드만 수행합니다.',
+      jobName: 'job1',
       config: {
-        name: "Gradle Build (no test)",
-        run: "chmod +x ./gradlew\n./gradlew clean build -x test",
+        name: 'Gradle Build (no test)',
+        run: 'chmod +x ./gradlew\n./gradlew clean build -x test',
       },
     },
     {
-      id: "step-gradle-test",
-      name: "Gradle 테스트 실행 블록",
-      type: "step",
-      domain: "gradle",
-      task: ["test"],
-      description: "Gradle을 사용하여 테스트를 수행하는 블록입니다.",
-      "job-name": "job1",
+      name: 'Gradle 테스트 실행 블록',
+      type: 'step',
+      domain: 'gradle',
+      task: ['test'],
+      description: 'Gradle을 사용하여 테스트를 수행하는 블록입니다.',
+      jobName: 'job1',
       config: {
-        name: "Test with Gradle",
-        run: "./gradlew test",
+        name: 'Test with Gradle',
+        run: './gradlew test',
       },
     },
     {
-      id: "step-docker-login",
-      name: "Docker 로그인",
-      type: "step",
-      domain: "docker",
-      task: ["login"],
-      description:
-        "Docker Hub에 로그인하여 이후 이미지 푸시에 권한을 부여합니다.",
-      "job-name": "job1",
+      name: 'Docker 로그인',
+      type: 'step',
+      domain: 'docker',
+      task: ['login'],
+      description: 'Docker Hub에 로그인하여 이후 이미지 푸시에 권한을 부여합니다.',
+      jobName: 'job1',
       config: {
-        name: "Docker Login",
-        uses: "docker/login-action@v2.2.0",
+        name: 'Docker Login',
+        uses: 'docker/login-action@v2.2.0',
         with: {
-          username: "${{ secrets.DOCKER_USERNAME }}",
-          password: "${{ secrets.DOCKER_PASSWORD }}",
+          username: '${{ secrets.DOCKER_USERNAME }}',
+          password: '${{ secrets.DOCKER_PASSWORD }}',
         },
       },
     },
     {
-      id: "step-docker-build-push",
-      name: "Docker 이미지 빌드 및 푸시 블록",
-      type: "step",
-      domain: "docker",
-      task: ["build", "push"],
-      description: "Docker 이미지를 빌드하고 Docker Hub에 푸시하는 단계입니다.",
-      "job-name": "job1",
+      name: 'Docker 이미지 빌드 및 푸시 블록',
+      type: 'step',
+      domain: 'docker',
+      task: ['build', 'push'],
+      description: 'Docker 이미지를 빌드하고 Docker Hub에 푸시하는 단계입니다.',
+      jobName: 'job1',
       config: {
-        name: "image build and push docker images",
-        uses: "docker/build-push-action@v4.1.1",
+        name: 'image build and push docker images',
+        uses: 'docker/build-push-action@v4.1.1',
         with: {
-          context: ".",
+          context: '.',
           push: true,
-          tags: "${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest",
-          "no-cache": true,
+          tags: '${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest',
+          'no-cache': true,
         },
       },
     },
     {
-      id: "step-aws-deploy",
-      name: "Deploy to AWS EC2",
-      type: "step",
-      domain: "aws",
-      task: ["deploy"],
-      description: "Docker 이미지를 EC2 서버에 배포하는 단계입니다.",
-      "job-name": "job1",
+      name: 'Deploy to AWS EC2',
+      type: 'step',
+      domain: 'aws',
+      task: ['deploy'],
+      description: 'Docker 이미지를 EC2 서버에 배포하는 단계입니다.',
+      jobName: 'job1',
       config: {
-        name: "Deploy to AWS EC2",
-        uses: "appleboy/ssh-action@v0.1.10",
+        name: 'Deploy to AWS EC2',
+        uses: 'appleboy/ssh-action@v0.1.10',
         with: {
-          host: "${{ secrets.AWS_HOST_IP }}",
-          username: "${{ secrets.REMOTE_USER }}",
-          key: "${{ secrets.AWS_EC2_PRIVATE_KEY }}",
-          port: "${{ secrets.REMOTE_SSH_PORT }}",
+          host: '${{ secrets.AWS_HOST_IP }}',
+          username: '${{ secrets.REMOTE_USER }}',
+          key: '${{ secrets.AWS_EC2_PRIVATE_KEY }}',
+          port: '${{ secrets.REMOTE_SSH_PORT }}',
           script:
             "docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}\ndocker pull ${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest\ndocker stop bus-notice-v2\ndocker rm $(docker ps --filter 'status=exited' -a -q)\ndocker run -d --name bus-notice-v2 --log-driver=syslog --network bus-notice -p 8081:8080 --label co.elastic.logs/enabled=true --label co.elastic.logs/module=java ${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest",
         },
       },
     },
   ],
+};
+
+//* ========================================
+//* 새로운 구조 예시 데이터
+//* ========================================
+
+//* 워크플로우 요청 예시 (프론트엔드 -> 백엔드)
+export const EXAMPLE_WORKFLOW_REQUEST: WorkflowRequest = {
+  owner: 'donghyuun',
+  repo: 'pipemate',
+  workflowName: 'T-FLOW1015',
+  inputJson: [
+    {
+      name: '워크플로우 기본 설정',
+      type: 'trigger',
+      description: 'GitHub Actions 워크플로우 이름과 트리거 조건을 설정하는 블록입니다.',
+      config: {
+        name: 'Java CICD',
+        on: {
+          workflow_dispatch: {},
+          push: {
+            branches: ['v2'],
+          },
+        },
+      },
+    },
+    {
+      name: 'Job 설정',
+      type: 'job',
+      jobName: 'job1',
+      description: '사용자 정의 job-id와 실행 환경을 설정하는 블록입니다.',
+      config: {
+        'runs-on': 'ubuntu-latest',
+      },
+    },
+    {
+      name: 'Checkout repository',
+      type: 'step',
+      jobName: 'job1',
+      domain: 'github',
+      task: ['checkout'],
+      description: 'GitHub 저장소를 체크아웃하는 단계입니다.',
+      config: {
+        name: 'Checkout repository',
+        uses: 'actions/checkout@v4',
+      },
+    },
+    {
+      name: 'Set up JDK 21',
+      type: 'step',
+      jobName: 'job1',
+      domain: 'java',
+      task: ['setup'],
+      description: 'GitHub Actions 실행 환경에 AdoptOpenJDK 21을 설치하는 단계입니다.',
+      config: {
+        name: 'Set up JDK 21',
+        uses: 'actions/setup-java@v4',
+        with: {
+          distribution: 'adopt',
+          'java-version': '21',
+        },
+      },
+    },
+    {
+      name: 'Gradle 빌드 블록',
+      type: 'step',
+      jobName: 'job1',
+      domain: 'gradle',
+      task: ['build'],
+      description: 'Gradle Wrapper에 권한을 부여하고, 테스트를 제외한 빌드만 수행합니다.',
+      config: {
+        name: 'Gradle Build (no test)',
+        run: 'chmod +x ./gradlew\n./gradlew clean build -x test',
+      },
+    },
+    {
+      name: 'Gradle 테스트 실행 블록',
+      type: 'step',
+      jobName: 'job1',
+      domain: 'gradle',
+      task: ['test'],
+      description: 'Gradle을 사용하여 테스트를 수행하는 블록입니다.',
+      config: {
+        name: 'Test with Gradle',
+        run: './gradlew test',
+      },
+    },
+    {
+      name: 'Docker 로그인',
+      type: 'step',
+      jobName: 'job1',
+      domain: 'docker',
+      task: ['login'],
+      description: 'Docker Hub에 로그인하여 이후 이미지 푸시에 권한을 부여합니다.',
+      config: {
+        name: 'Docker Login',
+        uses: 'docker/login-action@v2.2.0',
+        with: {
+          username: '${{ secrets.DOCKER_USERNAME }}',
+          password: '${{ secrets.DOCKER_PASSWORD }}',
+        },
+      },
+    },
+    {
+      name: 'Docker 이미지 빌드 및 푸시 블록',
+      type: 'step',
+      jobName: 'job1',
+      domain: 'docker',
+      task: ['build', 'push'],
+      description: 'Docker 이미지를 빌드하고 Docker Hub에 푸시하는 단계입니다.',
+      config: {
+        name: 'image build and push docker images',
+        uses: 'docker/build-push-action@v4.1.1',
+        with: {
+          context: '.',
+          push: true,
+          tags: '${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest',
+          'no-cache': true,
+        },
+      },
+    },
+    {
+      name: 'Deploy to AWS EC2',
+      type: 'step',
+      jobName: 'job1',
+      domain: 'aws',
+      task: ['deploy'],
+      description: 'Docker 이미지를 EC2 서버에 배포하는 단계입니다.',
+      config: {
+        name: 'Deploy to AWS EC2',
+        uses: 'appleboy/ssh-action@v0.1.10',
+        with: {
+          host: '${{ secrets.AWS_HOST_IP }}',
+          username: '${{ secrets.REMOTE_USER }}',
+          key: '${{ secrets.AWS_EC2_PRIVATE_KEY }}',
+          port: '${{ secrets.REMOTE_SSH_PORT }}',
+          script:
+            "docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}\ndocker pull ${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest\ndocker stop bus-notice-v2\ndocker rm $(docker ps --filter 'status=exited' -a -q)\ndocker run -d --name bus-notice-v2 --log-driver=syslog --network bus-notice -p 8081:8080 --label co.elastic.logs/enabled=true --label co.elastic.logs/module=java ${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest",
+        },
+      },
+    },
+    {
+      name: 'Job 설정2',
+      type: 'job',
+      jobName: 'job2',
+      description: '사용자 정의 job-id와 실행 환경을 설정하는 블록입니다.',
+      config: {
+        'runs-on': 'ubuntu-latest',
+      },
+    },
+    {
+      name: 'Checkout repository',
+      type: 'step',
+      jobName: 'job2',
+      domain: 'github',
+      task: ['checkout'],
+      description: 'GitHub 저장소를 체크아웃하는 단계입니다.22',
+      config: {
+        name: 'Checkout repository',
+        uses: 'actions/checkout@v4',
+      },
+    },
+  ],
+  description: 'Java CI/CD 파이프라인 예시',
+};
+
+//* 워크플로우 응답 예시 (백엔드 -> 프론트엔드)
+export const EXAMPLE_WORKFLOW_RESPONSE: WorkflowResponse = {
+  workflowId: '',
+  workflowName: 'T-FLOW1015',
+  originalJson: EXAMPLE_WORKFLOW_REQUEST.inputJson,
+  success: true,
+  message: 'Workflow loaded and parsed from GitHub',
 };
 
 //* ========================================
@@ -187,156 +385,154 @@ export const PRESET_PIPELINES: Record<string, PresetPipeline[]> = {
   //* CI/CD 파이프라인
   cicd: [
     {
-      id: "pipeline-java-cicd",
-      name: "Java CI/CD 파이프라인",
+      id: 'pipeline-java-cicd',
+      name: 'Java CI/CD 파이프라인',
       description:
-        "Java 프로젝트를 위한 완전한 CI/CD 파이프라인입니다. 빌드, 테스트, Docker 이미지 생성 및 배포를 포함합니다.",
-      type: "cicd",
-      domain: "java",
-      task: ["build", "test", "deploy"],
+        'Java 프로젝트를 위한 완전한 CI/CD 파이프라인입니다. 빌드, 테스트, Docker 이미지 생성 및 배포를 포함합니다.',
+      type: 'cicd',
+      domain: 'java',
+      task: ['build', 'test', 'deploy'],
       blocks: [
         {
-          id: "trigger-workflow-basic",
-          name: "워크플로우 기본 설정",
-          type: "trigger",
+          id: 'trigger-workflow-basic',
+          name: '워크플로우 기본 설정',
+          type: 'trigger',
           description:
-            "GitHub Actions 워크플로우 이름과 트리거 조건을 설정하는 블록입니다.",
+            'GitHub Actions 워크플로우 이름과 트리거 조건을 설정하는 블록입니다.',
           config: {
-            name: "Java CICD",
+            name: 'Java CICD',
             on: {
               workflow_dispatch: {},
               push: {
-                branches: ["v2"],
+                branches: ['v2'],
               },
             },
           },
         },
         {
-          id: "job-ci-pipeline",
-          name: "CI Pipeline Job",
-          type: "job",
-          description: "CI 파이프라인을 실행하는 Job입니다.",
-          "job-name": "job1",
+          id: 'job-ci-pipeline',
+          name: 'CI Pipeline Job',
+          type: 'job',
+          description: 'CI 파이프라인을 실행하는 Job입니다.',
+          'job-name': 'job1',
           config: {
             jobs: {
               job1: {
-                "runs-on": "ubuntu-latest",
+                'runs-on': 'ubuntu-latest',
               },
             },
           },
         },
         {
-          id: "step-checkout",
-          name: "Checkout repository",
-          type: "step",
-          domain: "github",
-          task: ["checkout"],
-          description: "GitHub 저장소를 체크아웃하는 단계입니다.",
-          "job-name": "job1",
+          id: 'step-checkout',
+          name: 'Checkout repository',
+          type: 'step',
+          domain: 'github',
+          task: ['checkout'],
+          description: 'GitHub 저장소를 체크아웃하는 단계입니다.',
+          'job-name': 'job1',
           config: {
-            name: "Checkout repository",
-            uses: "actions/checkout@v4",
+            name: 'Checkout repository',
+            uses: 'actions/checkout@v4',
           },
         },
         {
-          id: "step-java-setup",
-          name: "Set up JDK 21",
-          type: "step",
-          domain: "java",
-          task: ["setup"],
+          id: 'step-java-setup',
+          name: 'Set up JDK 21',
+          type: 'step',
+          domain: 'java',
+          task: ['setup'],
           description:
-            "GitHub Actions 실행 환경에 AdoptOpenJDK 21을 설치하는 단계입니다.",
-          "job-name": "job1",
+            'GitHub Actions 실행 환경에 AdoptOpenJDK 21을 설치하는 단계입니다.',
+          'job-name': 'job1',
           config: {
-            name: "Set up JDK 21",
-            uses: "actions/setup-java@v4",
+            name: 'Set up JDK 21',
+            uses: 'actions/setup-java@v4',
             with: {
-              distribution: "adopt",
-              "java-version": "21",
+              distribution: 'adopt',
+              'java-version': '21',
             },
           },
         },
         {
-          id: "step-gradle-build",
-          name: "Gradle 빌드 블록",
-          type: "step",
-          domain: "gradle",
-          task: ["build"],
+          id: 'step-gradle-build',
+          name: 'Gradle 빌드 블록',
+          type: 'step',
+          domain: 'gradle',
+          task: ['build'],
           description:
-            "Gradle Wrapper에 권한을 부여하고, 테스트를 제외한 빌드만 수행합니다.",
-          "job-name": "job1",
+            'Gradle Wrapper에 권한을 부여하고, 테스트를 제외한 빌드만 수행합니다.',
+          'job-name': 'job1',
           config: {
-            name: "Gradle Build (no test)",
-            run: "chmod +x ./gradlew\n./gradlew clean build -x test",
+            name: 'Gradle Build (no test)',
+            run: 'chmod +x ./gradlew\n./gradlew clean build -x test',
           },
         },
         {
-          id: "step-gradle-test",
-          name: "Gradle 테스트 실행 블록",
-          type: "step",
-          domain: "gradle",
-          task: ["test"],
-          description: "Gradle을 사용하여 테스트를 수행하는 블록입니다.",
-          "job-name": "job1",
+          id: 'step-gradle-test',
+          name: 'Gradle 테스트 실행 블록',
+          type: 'step',
+          domain: 'gradle',
+          task: ['test'],
+          description: 'Gradle을 사용하여 테스트를 수행하는 블록입니다.',
+          'job-name': 'job1',
           config: {
-            name: "Test with Gradle",
-            run: "./gradlew test",
+            name: 'Test with Gradle',
+            run: './gradlew test',
           },
         },
         {
-          id: "step-docker-login",
-          name: "Docker 로그인",
-          type: "step",
-          domain: "docker",
-          task: ["login"],
-          description:
-            "Docker Hub에 로그인하여 이후 이미지 푸시에 권한을 부여합니다.",
-          "job-name": "job1",
+          id: 'step-docker-login',
+          name: 'Docker 로그인',
+          type: 'step',
+          domain: 'docker',
+          task: ['login'],
+          description: 'Docker Hub에 로그인하여 이후 이미지 푸시에 권한을 부여합니다.',
+          'job-name': 'job1',
           config: {
-            name: "Docker Login",
-            uses: "docker/login-action@v2.2.0",
+            name: 'Docker Login',
+            uses: 'docker/login-action@v2.2.0',
             with: {
-              username: "${{ secrets.DOCKER_USERNAME }}",
-              password: "${{ secrets.DOCKER_PASSWORD }}",
+              username: '${{ secrets.DOCKER_USERNAME }}',
+              password: '${{ secrets.DOCKER_PASSWORD }}',
             },
           },
         },
         {
-          id: "step-docker-build-push",
-          name: "Docker 이미지 빌드 및 푸시 블록",
-          type: "step",
-          domain: "docker",
-          task: ["build", "push"],
-          description:
-            "Docker 이미지를 빌드하고 Docker Hub에 푸시하는 단계입니다.",
-          "job-name": "job1",
+          id: 'step-docker-build-push',
+          name: 'Docker 이미지 빌드 및 푸시 블록',
+          type: 'step',
+          domain: 'docker',
+          task: ['build', 'push'],
+          description: 'Docker 이미지를 빌드하고 Docker Hub에 푸시하는 단계입니다.',
+          'job-name': 'job1',
           config: {
-            name: "image build and push docker images",
-            uses: "docker/build-push-action@v4.1.1",
+            name: 'image build and push docker images',
+            uses: 'docker/build-push-action@v4.1.1',
             with: {
-              context: ".",
+              context: '.',
               push: true,
-              tags: "${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest",
-              "no-cache": true,
+              tags: '${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest',
+              'no-cache': true,
             },
           },
         },
         {
-          id: "step-aws-deploy",
-          name: "Deploy to AWS EC2",
-          type: "step",
-          domain: "aws",
-          task: ["deploy"],
-          description: "Docker 이미지를 EC2 서버에 배포하는 단계입니다.",
-          "job-name": "job1",
+          id: 'step-aws-deploy',
+          name: 'Deploy to AWS EC2',
+          type: 'step',
+          domain: 'aws',
+          task: ['deploy'],
+          description: 'Docker 이미지를 EC2 서버에 배포하는 단계입니다.',
+          'job-name': 'job1',
           config: {
-            name: "Deploy to AWS EC2",
-            uses: "appleboy/ssh-action@v0.1.10",
+            name: 'Deploy to AWS EC2',
+            uses: 'appleboy/ssh-action@v0.1.10',
             with: {
-              host: "${{ secrets.AWS_HOST_IP }}",
-              username: "${{ secrets.REMOTE_USER }}",
-              key: "${{ secrets.AWS_EC2_PRIVATE_KEY }}",
-              port: "${{ secrets.REMOTE_SSH_PORT }}",
+              host: '${{ secrets.AWS_HOST_IP }}',
+              username: '${{ secrets.REMOTE_USER }}',
+              key: '${{ secrets.AWS_EC2_PRIVATE_KEY }}',
+              port: '${{ secrets.REMOTE_SSH_PORT }}',
               script:
                 "docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}\ndocker pull ${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest\ndocker stop bus-notice-v2\ndocker rm $(docker ps --filter 'status=exited' -a -q)\ndocker run -d --name bus-notice-v2 --log-driver=syslog --network bus-notice -p 8081:8080 --label co.elastic.logs/enabled=true --label co.elastic.logs/module=java ${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest",
             },
@@ -344,63 +540,63 @@ export const PRESET_PIPELINES: Record<string, PresetPipeline[]> = {
         },
       ],
       config: {
-        name: "Java CICD",
+        name: 'Java CICD',
         on: {
           workflow_dispatch: {},
           push: {
-            branches: ["v2"],
+            branches: ['v2'],
           },
         },
         jobs: {
           job1: {
-            "runs-on": "ubuntu-latest",
+            'runs-on': 'ubuntu-latest',
             steps: [
               {
-                name: "Checkout repository",
-                uses: "actions/checkout@v4",
+                name: 'Checkout repository',
+                uses: 'actions/checkout@v4',
               },
               {
-                name: "Set up JDK 21",
-                uses: "actions/setup-java@v4",
+                name: 'Set up JDK 21',
+                uses: 'actions/setup-java@v4',
                 with: {
-                  distribution: "adopt",
-                  "java-version": "21",
+                  distribution: 'adopt',
+                  'java-version': '21',
                 },
               },
               {
-                name: "Gradle Build (no test)",
-                run: "chmod +x ./gradlew\n./gradlew clean build -x test",
+                name: 'Gradle Build (no test)',
+                run: 'chmod +x ./gradlew\n./gradlew clean build -x test',
               },
               {
-                name: "Test with Gradle",
-                run: "./gradlew test",
+                name: 'Test with Gradle',
+                run: './gradlew test',
               },
               {
-                name: "Docker Login",
-                uses: "docker/login-action@v2.2.0",
+                name: 'Docker Login',
+                uses: 'docker/login-action@v2.2.0',
                 with: {
-                  username: "${{ secrets.DOCKER_USERNAME }}",
-                  password: "${{ secrets.DOCKER_PASSWORD }}",
+                  username: '${{ secrets.DOCKER_USERNAME }}',
+                  password: '${{ secrets.DOCKER_PASSWORD }}',
                 },
               },
               {
-                name: "image build and push docker images",
-                uses: "docker/build-push-action@v4.1.1",
+                name: 'image build and push docker images',
+                uses: 'docker/build-push-action@v4.1.1',
                 with: {
-                  context: ".",
+                  context: '.',
                   push: true,
-                  tags: "${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest",
-                  "no-cache": true,
+                  tags: '${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest',
+                  'no-cache': true,
                 },
               },
               {
-                name: "Deploy to AWS EC2",
-                uses: "appleboy/ssh-action@v0.1.10",
+                name: 'Deploy to AWS EC2',
+                uses: 'appleboy/ssh-action@v0.1.10',
                 with: {
-                  host: "${{ secrets.AWS_HOST_IP }}",
-                  username: "${{ secrets.REMOTE_USER }}",
-                  key: "${{ secrets.AWS_EC2_PRIVATE_KEY }}",
-                  port: "${{ secrets.REMOTE_SSH_PORT }}",
+                  host: '${{ secrets.AWS_HOST_IP }}',
+                  username: '${{ secrets.REMOTE_USER }}',
+                  key: '${{ secrets.AWS_EC2_PRIVATE_KEY }}',
+                  port: '${{ secrets.REMOTE_SSH_PORT }}',
                   script:
                     "docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}\ndocker pull ${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest\ndocker stop bus-notice-v2\ndocker rm $(docker ps --filter 'status=exited' -a -q)\ndocker run -d --name bus-notice-v2 --log-driver=syslog --network bus-notice -p 8081:8080 --label co.elastic.logs/enabled=true --label co.elastic.logs/module=java ${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest",
                 },
@@ -416,140 +612,140 @@ export const PRESET_PIPELINES: Record<string, PresetPipeline[]> = {
   //* CI 파이프라인
   ci: [
     {
-      id: "pipeline-java-ci",
-      name: "Java CI 파이프라인",
+      id: 'pipeline-java-ci',
+      name: 'Java CI 파이프라인',
       description:
-        "Java 프로젝트를 위한 CI 파이프라인입니다. 빌드와 테스트를 포함합니다.",
-      type: "ci",
-      domain: "java",
-      task: ["build", "test"],
+        'Java 프로젝트를 위한 CI 파이프라인입니다. 빌드와 테스트를 포함합니다.',
+      type: 'ci',
+      domain: 'java',
+      task: ['build', 'test'],
       blocks: [
         {
-          id: "trigger-workflow-basic",
-          name: "워크플로우 기본 설정",
-          type: "trigger",
+          id: 'trigger-workflow-basic',
+          name: '워크플로우 기본 설정',
+          type: 'trigger',
           description:
-            "GitHub Actions 워크플로우 이름과 트리거 조건을 설정하는 블록입니다.",
+            'GitHub Actions 워크플로우 이름과 트리거 조건을 설정하는 블록입니다.',
           config: {
-            name: "Java CI",
+            name: 'Java CI',
             on: {
               workflow_dispatch: {},
               push: {
-                branches: ["main"],
+                branches: ['main'],
               },
               pull_request: {
-                branches: ["main"],
+                branches: ['main'],
               },
             },
           },
         },
         {
-          id: "job-ci-pipeline",
-          name: "CI Pipeline Job",
-          type: "job",
-          description: "CI 파이프라인을 실행하는 Job입니다.",
-          "job-name": "job1",
+          id: 'job-ci-pipeline',
+          name: 'CI Pipeline Job',
+          type: 'job',
+          description: 'CI 파이프라인을 실행하는 Job입니다.',
+          'job-name': 'job1',
           config: {
             jobs: {
               job1: {
-                "runs-on": "ubuntu-latest",
+                'runs-on': 'ubuntu-latest',
               },
             },
           },
         },
         {
-          id: "step-checkout",
-          name: "Checkout repository",
-          type: "step",
-          domain: "github",
-          task: ["checkout"],
-          description: "GitHub 저장소를 체크아웃하는 단계입니다.",
-          "job-name": "job1",
+          id: 'step-checkout',
+          name: 'Checkout repository',
+          type: 'step',
+          domain: 'github',
+          task: ['checkout'],
+          description: 'GitHub 저장소를 체크아웃하는 단계입니다.',
+          'job-name': 'job1',
           config: {
-            name: "Checkout repository",
-            uses: "actions/checkout@v4",
+            name: 'Checkout repository',
+            uses: 'actions/checkout@v4',
           },
         },
         {
-          id: "step-java-setup",
-          name: "Set up JDK 21",
-          type: "step",
-          domain: "java",
-          task: ["setup"],
+          id: 'step-java-setup',
+          name: 'Set up JDK 21',
+          type: 'step',
+          domain: 'java',
+          task: ['setup'],
           description:
-            "GitHub Actions 실행 환경에 AdoptOpenJDK 21을 설치하는 단계입니다.",
-          "job-name": "job1",
+            'GitHub Actions 실행 환경에 AdoptOpenJDK 21을 설치하는 단계입니다.',
+          'job-name': 'job1',
           config: {
-            name: "Set up JDK 21",
-            uses: "actions/setup-java@v4",
+            name: 'Set up JDK 21',
+            uses: 'actions/setup-java@v4',
             with: {
-              distribution: "adopt",
-              "java-version": "21",
+              distribution: 'adopt',
+              'java-version': '21',
             },
           },
         },
         {
-          id: "step-gradle-build",
-          name: "Gradle 빌드 블록",
-          type: "step",
-          domain: "gradle",
-          task: ["build"],
+          id: 'step-gradle-build',
+          name: 'Gradle 빌드 블록',
+          type: 'step',
+          domain: 'gradle',
+          task: ['build'],
           description:
-            "Gradle Wrapper에 권한을 부여하고, 테스트를 제외한 빌드만 수행합니다.",
-          "job-name": "job1",
+            'Gradle Wrapper에 권한을 부여하고, 테스트를 제외한 빌드만 수행합니다.',
+          'job-name': 'job1',
           config: {
-            name: "Gradle Build (no test)",
-            run: "chmod +x ./gradlew\n./gradlew clean build -x test",
+            name: 'Gradle Build (no test)',
+            run: 'chmod +x ./gradlew\n./gradlew clean build -x test',
           },
         },
         {
-          id: "step-gradle-test",
-          name: "Gradle 테스트 실행 블록",
-          type: "step",
-          domain: "gradle",
-          task: ["test"],
-          description: "Gradle을 사용하여 테스트를 수행하는 블록입니다.",
-          "job-name": "job1",
+          id: 'step-gradle-test',
+          name: 'Gradle 테스트 실행 블록',
+          type: 'step',
+          domain: 'gradle',
+          task: ['test'],
+          description: 'Gradle을 사용하여 테스트를 수행하는 블록입니다.',
+          'job-name': 'job1',
           config: {
-            name: "Test with Gradle",
-            run: "./gradlew test",
+            name: 'Test with Gradle',
+            run: './gradlew test',
           },
         },
       ],
       config: {
-        name: "Java CI",
+        name: 'Java CI',
         on: {
           workflow_dispatch: {},
           push: {
-            branches: ["main"],
+            branches: ['main'],
           },
           pull_request: {
-            branches: ["main"],
+            branches: ['main'],
           },
         },
         jobs: {
           job1: {
-            "runs-on": "ubuntu-latest",
+            'runs-on': 'ubuntu-latest',
             steps: [
               {
-                name: "Checkout repository",
-                uses: "actions/checkout@v4",
+                name: 'Checkout repository',
+                uses: 'actions/checkout@v4',
               },
               {
-                name: "Set up JDK 21",
-                uses: "actions/setup-java@v4",
+                name: 'Set up JDK 21',
+                uses: 'actions/setup-java@v4',
                 with: {
-                  distribution: "adopt",
-                  "java-version": "21",
+                  distribution: 'adopt',
+                  'java-version': '21',
                 },
               },
               {
-                name: "Gradle Build (no test)",
-                run: "chmod +x ./gradlew\n./gradlew clean build -x test",
+                name: 'Gradle Build (no test)',
+                run: 'chmod +x ./gradlew\n./gradlew clean build -x test',
               },
               {
-                name: "Test with Gradle",
-                run: "./gradlew test",
+                name: 'Test with Gradle',
+                run: './gradlew test',
               },
             ],
           },
@@ -562,110 +758,108 @@ export const PRESET_PIPELINES: Record<string, PresetPipeline[]> = {
   //* CD 파이프라인
   cd: [
     {
-      id: "pipeline-docker-deploy",
-      name: "Docker 배포 파이프라인",
-      description: "Docker 이미지를 빌드하고 배포하는 CD 파이프라인입니다.",
-      type: "cd",
-      domain: "docker",
-      task: ["build", "deploy"],
+      id: 'pipeline-docker-deploy',
+      name: 'Docker 배포 파이프라인',
+      description: 'Docker 이미지를 빌드하고 배포하는 CD 파이프라인입니다.',
+      type: 'cd',
+      domain: 'docker',
+      task: ['build', 'deploy'],
       blocks: [
         {
-          id: "trigger-workflow-basic",
-          name: "워크플로우 기본 설정",
-          type: "trigger",
+          id: 'trigger-workflow-basic',
+          name: '워크플로우 기본 설정',
+          type: 'trigger',
           description:
-            "GitHub Actions 워크플로우 이름과 트리거 조건을 설정하는 블록입니다.",
+            'GitHub Actions 워크플로우 이름과 트리거 조건을 설정하는 블록입니다.',
           config: {
-            name: "Docker Deploy",
+            name: 'Docker Deploy',
             on: {
               workflow_dispatch: {},
               push: {
-                branches: ["production"],
+                branches: ['production'],
               },
             },
           },
         },
         {
-          id: "job-deploy-pipeline",
-          name: "Deploy Pipeline Job",
-          type: "job",
-          description: "배포 파이프라인을 실행하는 Job입니다.",
-          "job-name": "job1",
+          id: 'job-deploy-pipeline',
+          name: 'Deploy Pipeline Job',
+          type: 'job',
+          description: '배포 파이프라인을 실행하는 Job입니다.',
+          'job-name': 'job1',
           config: {
             jobs: {
               job1: {
-                "runs-on": "ubuntu-latest",
+                'runs-on': 'ubuntu-latest',
               },
             },
           },
         },
         {
-          id: "step-checkout",
-          name: "Checkout repository",
-          type: "step",
-          domain: "github",
-          task: ["checkout"],
-          description: "GitHub 저장소를 체크아웃하는 단계입니다.",
-          "job-name": "job1",
+          id: 'step-checkout',
+          name: 'Checkout repository',
+          type: 'step',
+          domain: 'github',
+          task: ['checkout'],
+          description: 'GitHub 저장소를 체크아웃하는 단계입니다.',
+          'job-name': 'job1',
           config: {
-            name: "Checkout repository",
-            uses: "actions/checkout@v4",
+            name: 'Checkout repository',
+            uses: 'actions/checkout@v4',
           },
         },
         {
-          id: "step-docker-login",
-          name: "Docker 로그인",
-          type: "step",
-          domain: "docker",
-          task: ["login"],
-          description:
-            "Docker Hub에 로그인하여 이후 이미지 푸시에 권한을 부여합니다.",
-          "job-name": "job1",
+          id: 'step-docker-login',
+          name: 'Docker 로그인',
+          type: 'step',
+          domain: 'docker',
+          task: ['login'],
+          description: 'Docker Hub에 로그인하여 이후 이미지 푸시에 권한을 부여합니다.',
+          'job-name': 'job1',
           config: {
-            name: "Docker Login",
-            uses: "docker/login-action@v2.2.0",
+            name: 'Docker Login',
+            uses: 'docker/login-action@v2.2.0',
             with: {
-              username: "${{ secrets.DOCKER_USERNAME }}",
-              password: "${{ secrets.DOCKER_PASSWORD }}",
+              username: '${{ secrets.DOCKER_USERNAME }}',
+              password: '${{ secrets.DOCKER_PASSWORD }}',
             },
           },
         },
         {
-          id: "step-docker-build-push",
-          name: "Docker 이미지 빌드 및 푸시 블록",
-          type: "step",
-          domain: "docker",
-          task: ["build", "push"],
-          description:
-            "Docker 이미지를 빌드하고 Docker Hub에 푸시하는 단계입니다.",
-          "job-name": "job1",
+          id: 'step-docker-build-push',
+          name: 'Docker 이미지 빌드 및 푸시 블록',
+          type: 'step',
+          domain: 'docker',
+          task: ['build', 'push'],
+          description: 'Docker 이미지를 빌드하고 Docker Hub에 푸시하는 단계입니다.',
+          'job-name': 'job1',
           config: {
-            name: "image build and push docker images",
-            uses: "docker/build-push-action@v4.1.1",
+            name: 'image build and push docker images',
+            uses: 'docker/build-push-action@v4.1.1',
             with: {
-              context: ".",
+              context: '.',
               push: true,
-              tags: "${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest",
-              "no-cache": true,
+              tags: '${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest',
+              'no-cache': true,
             },
           },
         },
         {
-          id: "step-aws-deploy",
-          name: "Deploy to AWS EC2",
-          type: "step",
-          domain: "aws",
-          task: ["deploy"],
-          description: "Docker 이미지를 EC2 서버에 배포하는 단계입니다.",
-          "job-name": "job1",
+          id: 'step-aws-deploy',
+          name: 'Deploy to AWS EC2',
+          type: 'step',
+          domain: 'aws',
+          task: ['deploy'],
+          description: 'Docker 이미지를 EC2 서버에 배포하는 단계입니다.',
+          'job-name': 'job1',
           config: {
-            name: "Deploy to AWS EC2",
-            uses: "appleboy/ssh-action@v0.1.10",
+            name: 'Deploy to AWS EC2',
+            uses: 'appleboy/ssh-action@v0.1.10',
             with: {
-              host: "${{ secrets.AWS_HOST_IP }}",
-              username: "${{ secrets.REMOTE_USER }}",
-              key: "${{ secrets.AWS_EC2_PRIVATE_KEY }}",
-              port: "${{ secrets.REMOTE_SSH_PORT }}",
+              host: '${{ secrets.AWS_HOST_IP }}',
+              username: '${{ secrets.REMOTE_USER }}',
+              key: '${{ secrets.AWS_EC2_PRIVATE_KEY }}',
+              port: '${{ secrets.REMOTE_SSH_PORT }}',
               script:
                 "docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}\ndocker pull ${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest\ndocker stop bus-notice-v2\ndocker rm $(docker ps --filter 'status=exited' -a -q)\ndocker run -d --name bus-notice-v2 --log-driver=syslog --network bus-notice -p 8081:8080 --label co.elastic.logs/enabled=true --label co.elastic.logs/module=java ${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest",
             },
@@ -673,47 +867,47 @@ export const PRESET_PIPELINES: Record<string, PresetPipeline[]> = {
         },
       ],
       config: {
-        name: "Docker Deploy",
+        name: 'Docker Deploy',
         on: {
           workflow_dispatch: {},
           push: {
-            branches: ["production"],
+            branches: ['production'],
           },
         },
         jobs: {
           job1: {
-            "runs-on": "ubuntu-latest",
+            'runs-on': 'ubuntu-latest',
             steps: [
               {
-                name: "Checkout repository",
-                uses: "actions/checkout@v4",
+                name: 'Checkout repository',
+                uses: 'actions/checkout@v4',
               },
               {
-                name: "Docker Login",
-                uses: "docker/login-action@v2.2.0",
+                name: 'Docker Login',
+                uses: 'docker/login-action@v2.2.0',
                 with: {
-                  username: "${{ secrets.DOCKER_USERNAME }}",
-                  password: "${{ secrets.DOCKER_PASSWORD }}",
+                  username: '${{ secrets.DOCKER_USERNAME }}',
+                  password: '${{ secrets.DOCKER_PASSWORD }}',
                 },
               },
               {
-                name: "image build and push docker images",
-                uses: "docker/build-push-action@v4.1.1",
+                name: 'image build and push docker images',
+                uses: 'docker/build-push-action@v4.1.1',
                 with: {
-                  context: ".",
+                  context: '.',
                   push: true,
-                  tags: "${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest",
-                  "no-cache": true,
+                  tags: '${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest',
+                  'no-cache': true,
                 },
               },
               {
-                name: "Deploy to AWS EC2",
-                uses: "appleboy/ssh-action@v0.1.10",
+                name: 'Deploy to AWS EC2',
+                uses: 'appleboy/ssh-action@v0.1.10',
                 with: {
-                  host: "${{ secrets.AWS_HOST_IP }}",
-                  username: "${{ secrets.REMOTE_USER }}",
-                  key: "${{ secrets.AWS_EC2_PRIVATE_KEY }}",
-                  port: "${{ secrets.REMOTE_SSH_PORT }}",
+                  host: '${{ secrets.AWS_HOST_IP }}',
+                  username: '${{ secrets.REMOTE_USER }}',
+                  key: '${{ secrets.AWS_EC2_PRIVATE_KEY }}',
+                  port: '${{ secrets.REMOTE_SSH_PORT }}',
                   script:
                     "docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}\ndocker pull ${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest\ndocker stop bus-notice-v2\ndocker rm $(docker ps --filter 'status=exited' -a -q)\ndocker run -d --name bus-notice-v2 --log-driver=syslog --network bus-notice -p 8081:8080 --label co.elastic.logs/enabled=true --label co.elastic.logs/module=java ${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest",
                 },
@@ -729,121 +923,121 @@ export const PRESET_PIPELINES: Record<string, PresetPipeline[]> = {
   //* 테스트 파이프라인
   test: [
     {
-      id: "pipeline-java-test",
-      name: "Java 테스트 파이프라인",
-      description: "Java 프로젝트를 위한 테스트 전용 파이프라인입니다.",
-      type: "test",
-      domain: "java",
-      task: ["test"],
+      id: 'pipeline-java-test',
+      name: 'Java 테스트 파이프라인',
+      description: 'Java 프로젝트를 위한 테스트 전용 파이프라인입니다.',
+      type: 'test',
+      domain: 'java',
+      task: ['test'],
       blocks: [
         {
-          id: "trigger-workflow-basic",
-          name: "워크플로우 기본 설정",
-          type: "trigger",
+          id: 'trigger-workflow-basic',
+          name: '워크플로우 기본 설정',
+          type: 'trigger',
           description:
-            "GitHub Actions 워크플로우 이름과 트리거 조건을 설정하는 블록입니다.",
+            'GitHub Actions 워크플로우 이름과 트리거 조건을 설정하는 블록입니다.',
           config: {
-            name: "Java Test",
+            name: 'Java Test',
             on: {
               workflow_dispatch: {},
               push: {
-                branches: ["main"],
+                branches: ['main'],
               },
               pull_request: {
-                branches: ["main"],
+                branches: ['main'],
               },
             },
           },
         },
         {
-          id: "job-test-pipeline",
-          name: "Test Pipeline Job",
-          type: "job",
-          description: "테스트 파이프라인을 실행하는 Job입니다.",
-          "job-name": "job1",
+          id: 'job-test-pipeline',
+          name: 'Test Pipeline Job',
+          type: 'job',
+          description: '테스트 파이프라인을 실행하는 Job입니다.',
+          'job-name': 'job1',
           config: {
             jobs: {
               job1: {
-                "runs-on": "ubuntu-latest",
+                'runs-on': 'ubuntu-latest',
               },
             },
           },
         },
         {
-          id: "step-checkout",
-          name: "Checkout repository",
-          type: "step",
-          domain: "github",
-          task: ["checkout"],
-          description: "GitHub 저장소를 체크아웃하는 단계입니다.",
-          "job-name": "job1",
+          id: 'step-checkout',
+          name: 'Checkout repository',
+          type: 'step',
+          domain: 'github',
+          task: ['checkout'],
+          description: 'GitHub 저장소를 체크아웃하는 단계입니다.',
+          'job-name': 'job1',
           config: {
-            name: "Checkout repository",
-            uses: "actions/checkout@v4",
+            name: 'Checkout repository',
+            uses: 'actions/checkout@v4',
           },
         },
         {
-          id: "step-java-setup",
-          name: "Set up JDK 21",
-          type: "step",
-          domain: "java",
-          task: ["setup"],
+          id: 'step-java-setup',
+          name: 'Set up JDK 21',
+          type: 'step',
+          domain: 'java',
+          task: ['setup'],
           description:
-            "GitHub Actions 실행 환경에 AdoptOpenJDK 21을 설치하는 단계입니다.",
-          "job-name": "job1",
+            'GitHub Actions 실행 환경에 AdoptOpenJDK 21을 설치하는 단계입니다.',
+          'job-name': 'job1',
           config: {
-            name: "Set up JDK 21",
-            uses: "actions/setup-java@v4",
+            name: 'Set up JDK 21',
+            uses: 'actions/setup-java@v4',
             with: {
-              distribution: "adopt",
-              "java-version": "21",
+              distribution: 'adopt',
+              'java-version': '21',
             },
           },
         },
         {
-          id: "step-gradle-test",
-          name: "Gradle 테스트 실행 블록",
-          type: "step",
-          domain: "gradle",
-          task: ["test"],
-          description: "Gradle을 사용하여 테스트를 수행하는 블록입니다.",
-          "job-name": "job1",
+          id: 'step-gradle-test',
+          name: 'Gradle 테스트 실행 블록',
+          type: 'step',
+          domain: 'gradle',
+          task: ['test'],
+          description: 'Gradle을 사용하여 테스트를 수행하는 블록입니다.',
+          'job-name': 'job1',
           config: {
-            name: "Test with Gradle",
-            run: "./gradlew test",
+            name: 'Test with Gradle',
+            run: './gradlew test',
           },
         },
       ],
       config: {
-        name: "Java Test",
+        name: 'Java Test',
         on: {
           workflow_dispatch: {},
           push: {
-            branches: ["main"],
+            branches: ['main'],
           },
           pull_request: {
-            branches: ["main"],
+            branches: ['main'],
           },
         },
         jobs: {
           job1: {
-            "runs-on": "ubuntu-latest",
+            'runs-on': 'ubuntu-latest',
             steps: [
               {
-                name: "Checkout repository",
-                uses: "actions/checkout@v4",
+                name: 'Checkout repository',
+                uses: 'actions/checkout@v4',
               },
               {
-                name: "Set up JDK 21",
-                uses: "actions/setup-java@v4",
+                name: 'Set up JDK 21',
+                uses: 'actions/setup-java@v4',
                 with: {
-                  distribution: "adopt",
-                  "java-version": "21",
+                  distribution: 'adopt',
+                  'java-version': '21',
                 },
               },
               {
-                name: "Test with Gradle",
-                run: "./gradlew test",
+                name: 'Test with Gradle',
+                run: './gradlew test',
               },
             ],
           },
@@ -856,72 +1050,72 @@ export const PRESET_PIPELINES: Record<string, PresetPipeline[]> = {
   //* 배포 파이프라인
   deploy: [
     {
-      id: "pipeline-aws-deploy",
-      name: "AWS 배포 파이프라인",
-      description: "AWS EC2에 애플리케이션을 배포하는 파이프라인입니다.",
-      type: "deploy",
-      domain: "aws",
-      task: ["deploy"],
+      id: 'pipeline-aws-deploy',
+      name: 'AWS 배포 파이프라인',
+      description: 'AWS EC2에 애플리케이션을 배포하는 파이프라인입니다.',
+      type: 'deploy',
+      domain: 'aws',
+      task: ['deploy'],
       blocks: [
         {
-          id: "trigger-workflow-basic",
-          name: "워크플로우 기본 설정",
-          type: "trigger",
+          id: 'trigger-workflow-basic',
+          name: '워크플로우 기본 설정',
+          type: 'trigger',
           description:
-            "GitHub Actions 워크플로우 이름과 트리거 조건을 설정하는 블록입니다.",
+            'GitHub Actions 워크플로우 이름과 트리거 조건을 설정하는 블록입니다.',
           config: {
-            name: "AWS Deploy",
+            name: 'AWS Deploy',
             on: {
               workflow_dispatch: {},
               push: {
-                branches: ["production"],
+                branches: ['production'],
               },
             },
           },
         },
         {
-          id: "job-deploy-pipeline",
-          name: "Deploy Pipeline Job",
-          type: "job",
-          description: "배포 파이프라인을 실행하는 Job입니다.",
-          "job-name": "job1",
+          id: 'job-deploy-pipeline',
+          name: 'Deploy Pipeline Job',
+          type: 'job',
+          description: '배포 파이프라인을 실행하는 Job입니다.',
+          'job-name': 'job1',
           config: {
             jobs: {
               job1: {
-                "runs-on": "ubuntu-latest",
+                'runs-on': 'ubuntu-latest',
               },
             },
           },
         },
         {
-          id: "step-checkout",
-          name: "Checkout repository",
-          type: "step",
-          domain: "github",
-          task: ["checkout"],
-          description: "GitHub 저장소를 체크아웃하는 단계입니다.",
-          "job-name": "job1",
+          id: 'step-checkout',
+          name: 'Checkout repository',
+          type: 'step',
+          domain: 'github',
+          task: ['checkout'],
+          description: 'GitHub 저장소를 체크아웃하는 단계입니다.',
+          'job-name': 'job1',
           config: {
-            name: "Checkout repository",
-            uses: "actions/checkout@v4",
+            name: 'Checkout repository',
+            uses: 'actions/checkout@v4',
           },
         },
         {
-          id: "step-aws-deploy",
-          name: "Deploy to AWS EC2",
-          type: "step",
-          domain: "aws",
-          task: ["deploy"],
-          description: "Docker 이미지를 EC2 서버에 배포하는 단계입니다.",
-          "job-name": "job1",
+          id: 'step-aws-deploy',
+          name: 'Deploy to AWS EC2',
+          type: 'step',
+          domain: 'aws',
+          task: ['deploy'],
+          description: 'Docker 이미지를 EC2 서버에 배포하는 단계입니다.',
+          'job-name': 'job1',
           config: {
-            name: "Deploy to AWS EC2",
-            uses: "appleboy/ssh-action@v0.1.10",
+            name: 'Deploy to AWS EC2',
+            uses: 'appleboy/ssh-action@v0.1.10',
             with: {
-              host: "${{ secrets.AWS_HOST_IP }}",
-              username: "${{ secrets.REMOTE_USER }}",
-              key: "${{ secrets.AWS_EC2_PRIVATE_KEY }}",
-              port: "${{ secrets.REMOTE_SSH_PORT }}",
+              host: '${{ secrets.AWS_HOST_IP }}',
+              username: '${{ secrets.REMOTE_USER }}',
+              key: '${{ secrets.AWS_EC2_PRIVATE_KEY }}',
+              port: '${{ secrets.REMOTE_SSH_PORT }}',
               script:
                 "docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}\ndocker pull ${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest\ndocker stop bus-notice-v2\ndocker rm $(docker ps --filter 'status=exited' -a -q)\ndocker run -d --name bus-notice-v2 --log-driver=syslog --network bus-notice -p 8081:8080 --label co.elastic.logs/enabled=true --label co.elastic.logs/module=java ${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest",
             },
@@ -929,29 +1123,29 @@ export const PRESET_PIPELINES: Record<string, PresetPipeline[]> = {
         },
       ],
       config: {
-        name: "AWS Deploy",
+        name: 'AWS Deploy',
         on: {
           workflow_dispatch: {},
           push: {
-            branches: ["production"],
+            branches: ['production'],
           },
         },
         jobs: {
           job1: {
-            "runs-on": "ubuntu-latest",
+            'runs-on': 'ubuntu-latest',
             steps: [
               {
-                name: "Checkout repository",
-                uses: "actions/checkout@v4",
+                name: 'Checkout repository',
+                uses: 'actions/checkout@v4',
               },
               {
-                name: "Deploy to AWS EC2",
-                uses: "appleboy/ssh-action@v0.1.10",
+                name: 'Deploy to AWS EC2',
+                uses: 'appleboy/ssh-action@v0.1.10',
                 with: {
-                  host: "${{ secrets.AWS_HOST_IP }}",
-                  username: "${{ secrets.REMOTE_USER }}",
-                  key: "${{ secrets.AWS_EC2_PRIVATE_KEY }}",
-                  port: "${{ secrets.REMOTE_SSH_PORT }}",
+                  host: '${{ secrets.AWS_HOST_IP }}',
+                  username: '${{ secrets.REMOTE_USER }}',
+                  key: '${{ secrets.AWS_EC2_PRIVATE_KEY }}',
+                  port: '${{ secrets.REMOTE_SSH_PORT }}',
                   script:
                     "docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}\ndocker pull ${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest\ndocker stop bus-notice-v2\ndocker rm $(docker ps --filter 'status=exited' -a -q)\ndocker run -d --name bus-notice-v2 --log-driver=syslog --network bus-notice -p 8081:8080 --label co.elastic.logs/enabled=true --label co.elastic.logs/module=java ${{ secrets.DOCKER_USERNAME }}/bus-notice-v2:latest",
                 },
@@ -970,49 +1164,272 @@ export const PRESET_PIPELINES: Record<string, PresetPipeline[]> = {
 //* ========================================
 
 //* 프리셋 블록 데이터를 가져오는 함수 (API 호출 시뮬레이션)
-export const fetchPresetBlocks = async (): Promise<
-  Record<string, PresetBlock[]>
-> => {
-  //* 실제로는 백엔드 API 호출
-  //* const response = await fetch('/api/preset-blocks');
-  //* return response.json();
+export const fetchPresetBlocks = async (): Promise<Record<string, BlockData[]>> => {
+  if (USE_REAL_API) {
+    //* 실제 백엔드 API 호출
+    const response = await fetch(`${API_CONFIG.BASE_URL}${API_ENDPOINTS.PRESETS.BLOCKS}`);
 
-  //* 현재는 목 데이터 반환
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve(PRESET_BLOCKS);
-    }, 100); //* API 호출 시뮬레이션을 위한 지연
-  });
+    if (!response.ok) {
+      throw new Error(
+        `Preset blocks retrieval failed: ${getErrorMessage(response.status)}`,
+      );
+    }
+
+    const blocks = await response.json();
+    //* 백엔드에서 받은 블록들을 탭별로 그룹화
+    const groupedBlocks: Record<string, BlockData[]> = {
+      trigger: blocks.filter((block: BlockData) => block.type === 'trigger'),
+      job: blocks.filter((block: BlockData) => block.type === 'job'),
+      step: blocks.filter((block: BlockData) => block.type === 'step'),
+    };
+
+    return groupedBlocks;
+  } else {
+    //* 목 데이터 반환
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(PRESET_BLOCKS);
+      }, 100); //* API 호출 시뮬레이션을 위한 지연
+    });
+  }
 };
 
 //* 프리셋 파이프라인 데이터를 가져오는 함수 (API 호출 시뮬레이션)
 export const fetchPresetPipelines = async (): Promise<
   Record<string, PresetPipeline[]>
 > => {
-  //* 실제로는 백엔드 API 호출
-  //* const response = await fetch('/api/preset-pipelines');
-  //* return response.json();
+  if (USE_REAL_API) {
+    //* 실제 백엔드 API 호출
+    const response = await fetch(
+      `${API_CONFIG.BASE_URL}${API_ENDPOINTS.PRESETS.PIPELINES}`,
+    );
 
-  //* 현재는 목 데이터 반환
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve(PRESET_PIPELINES);
-    }, 100); //* API 호출 시뮬레이션을 위한 지연
-  });
+    if (!response.ok) {
+      throw new Error(
+        `Preset pipelines retrieval failed: ${getErrorMessage(response.status)}`,
+      );
+    }
+
+    const pipelines = await response.json();
+    //* 백엔드에서 받은 파이프라인들을 타입별로 그룹화
+    const groupedPipelines: Record<string, PresetPipeline[]> = {
+      cicd: pipelines.filter((pipeline: any) => pipeline.type === 'cicd'),
+      ci: pipelines.filter((pipeline: any) => pipeline.type === 'ci'),
+      cd: pipelines.filter((pipeline: any) => pipeline.type === 'cd'),
+      test: pipelines.filter((pipeline: any) => pipeline.type === 'test'),
+      deploy: pipelines.filter((pipeline: any) => pipeline.type === 'deploy'),
+    };
+
+    return groupedPipelines;
+  } else {
+    //* 목 데이터 반환
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(PRESET_PIPELINES);
+      }, 100); //* API 호출 시뮬레이션을 위한 지연
+    });
+  }
 };
 
 //* 특정 탭의 프리셋 블록을 가져오는 함수
-export const fetchPresetBlocksByTab = async (
-  tab: string
-): Promise<PresetBlock[]> => {
+export const fetchPresetBlocksByTab = async (tab: string): Promise<BlockData[]> => {
   const allBlocks = await fetchPresetBlocks();
   return allBlocks[tab] || [];
 };
 
 //* 특정 탭의 프리셋 파이프라인을 가져오는 함수
 export const fetchPresetPipelinesByTab = async (
-  tab: string
+  tab: string,
 ): Promise<PresetPipeline[]> => {
   const allPipelines = await fetchPresetPipelines();
   return allPipelines[tab] || [];
+};
+
+//* ========================================
+//* 백엔드 API와 일치하는 함수들
+//* ========================================
+
+//* 실제 API 사용 여부 설정 (환경변수나 설정으로 제어 가능)
+const USE_REAL_API = API_CONFIG.USE_REAL_API;
+
+//* 파이프라인 생성 (POST /api/pipelines)
+export const createPipeline = async (request: WorkflowRequest): Promise<string> => {
+  if (USE_REAL_API) {
+    //* 실제 백엔드 API 호출
+    const token = localStorage.getItem('github_token') || '';
+    const response = await fetch(
+      `${API_CONFIG.BASE_URL}${API_ENDPOINTS.PIPELINES.CREATE}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(request),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Pipeline creation failed: ${getErrorMessage(response.status)}`);
+    }
+
+    return response.text();
+  } else {
+    //* 목 데이터 반환
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve('Workflow conversion and upload on github successful');
+      }, 200);
+    });
+  }
+};
+
+//* 파이프라인 조회 (GET /api/pipelines/{ymlFileName})
+export const getPipeline = async (
+  ymlFileName: string,
+  owner: string,
+  repo: string,
+): Promise<WorkflowResponse> => {
+  if (USE_REAL_API) {
+    //* 실제 백엔드 API 호출
+    const token = localStorage.getItem('github_token') || '';
+    const response = await fetch(
+      `${API_CONFIG.BASE_URL}${API_ENDPOINTS.PIPELINES.GET(ymlFileName, owner, repo)}`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Pipeline retrieval failed: ${getErrorMessage(response.status)}`);
+    }
+
+    return response.json();
+  } else {
+    //* 목 데이터 반환
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(EXAMPLE_WORKFLOW_RESPONSE);
+      }, 200);
+    });
+  }
+};
+
+//* 파이프라인 업데이트 (PUT /api/pipelines)
+export const updatePipeline = async (
+  request: WorkflowRequest,
+): Promise<WorkflowResponse> => {
+  if (USE_REAL_API) {
+    //* 실제 백엔드 API 호출
+    const token = localStorage.getItem('github_token') || '';
+    const response = await fetch(
+      `${API_CONFIG.BASE_URL}${API_ENDPOINTS.PIPELINES.UPDATE}`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(request),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Pipeline update failed: ${getErrorMessage(response.status)}`);
+    }
+
+    return response.json();
+  } else {
+    //* 목 데이터 반환
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve({
+          workflowId: 'updated-id',
+          workflowName: request.workflowName,
+          originalJson: request.inputJson,
+          success: true,
+          message: 'Workflow updated successfully',
+        });
+      }, 200);
+    });
+  }
+};
+
+//* 파이프라인 삭제 (DELETE /api/pipelines/{ymlFileName})
+export const deletePipeline = async (
+  ymlFileName: string,
+  owner: string,
+  repo: string,
+): Promise<void> => {
+  if (USE_REAL_API) {
+    //* 실제 백엔드 API 호출
+    const token = localStorage.getItem('github_token') || '';
+    const response = await fetch(
+      `${API_CONFIG.BASE_URL}${API_ENDPOINTS.PIPELINES.DELETE(ymlFileName, owner, repo)}`,
+      {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Pipeline deletion failed: ${getErrorMessage(response.status)}`);
+    }
+  } else {
+    //* 목 데이터 반환
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, 200);
+    });
+  }
+};
+
+//* 프리셋 블록 조회 (GET /api/presets/blocks)
+export const getPresetBlocks = async (): Promise<BlockData[]> => {
+  if (USE_REAL_API) {
+    //* 실제 백엔드 API 호출
+    const response = await fetch(`${API_CONFIG.BASE_URL}${API_ENDPOINTS.PRESETS.BLOCKS}`);
+
+    if (!response.ok) {
+      throw new Error(
+        `Preset blocks retrieval failed: ${getErrorMessage(response.status)}`,
+      );
+    }
+
+    return response.json();
+  } else {
+    //* 목 데이터 반환
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        const allBlocks = Object.values(PRESET_BLOCKS).flat();
+        resolve(allBlocks);
+      }, 200);
+    });
+  }
+};
+
+//* 프리셋 파이프라인 조회 (GET /api/presets/pipelines)
+export const getPresetPipelines = async (): Promise<WorkflowResponse[]> => {
+  if (USE_REAL_API) {
+    //* 실제 백엔드 API 호출
+    const response = await fetch(
+      `${API_CONFIG.BASE_URL}${API_ENDPOINTS.PRESETS.PIPELINES}`,
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Preset pipelines retrieval failed: ${getErrorMessage(response.status)}`,
+      );
+    }
+
+    return response.json();
+  } else {
+    //* 목 데이터 반환
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve([EXAMPLE_WORKFLOW_RESPONSE]);
+      }, 200);
+    });
+  }
 };

--- a/src/app/github-actions-flow/utils/yamlGenerator.ts
+++ b/src/app/github-actions-flow/utils/yamlGenerator.ts
@@ -4,7 +4,15 @@
 //* 이 파일은 서버 블록 데이터를 GitHub Actions YAML 형식으로 변환합니다.
 //* 단일 블록의 YAML과 전체 워크플로우 YAML을 생성할 수 있습니다.
 
-import { ServerBlock } from "../types";
+import { ServerBlock } from '../types';
+
+// 내부 유틸: job-id 생성 (공백→하이픈, 소문자, 안전 문자만 유지)
+const toJobId = (raw: string) =>
+  (raw || 'job')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-_]/g, '');
 
 //* ========================================
 //* 단일 블록 YAML 생성
@@ -17,50 +25,46 @@ export const generateBlockYaml = (block: ServerBlock): string => {
 
   // config가 없으면 빈 문자열 반환
   if (!block || !block.config) {
-    return "# 설정이 없습니다.";
+    return '# 설정이 없습니다.';
   }
 
   //* ========================================
   //* 트리거 블록 YAML 생성
   //* ========================================
-  if (block.type === "trigger") {
+  if (block.type === 'trigger') {
     //* config 내용만 사용하여 YAML 생성
     Object.entries(block.config).forEach(([key, value]) => {
-      if (typeof value === "string") {
+      if (typeof value === 'string') {
         yamlLines.push(`${key}: ${value}`);
-      } else if (typeof value === "object" && value !== null) {
+      } else if (typeof value === 'object' && value !== null) {
         yamlLines.push(`${key}:`);
         if (Array.isArray(value)) {
           value.forEach((item: unknown) => {
-            if (typeof item === "string") {
+            if (typeof item === 'string') {
               yamlLines.push(`  - ${item}`);
-            } else if (typeof item === "object" && item !== null) {
-              Object.entries(item as Record<string, unknown>).forEach(
-                ([k, v]) => {
-                  if (typeof v === "string") {
-                    yamlLines.push(`    ${k}: ${v}`);
-                  } else {
-                    yamlLines.push(`    ${k}: ${JSON.stringify(v)}`);
-                  }
+            } else if (typeof item === 'object' && item !== null) {
+              Object.entries(item as Record<string, unknown>).forEach(([k, v]) => {
+                if (typeof v === 'string') {
+                  yamlLines.push(`    ${k}: ${v}`);
+                } else {
+                  yamlLines.push(`    ${k}: ${JSON.stringify(v)}`);
                 }
-              );
+              });
             }
           });
         } else {
           Object.entries(value as Record<string, unknown>).forEach(([k, v]) => {
-            if (typeof v === "string") {
+            if (typeof v === 'string') {
               yamlLines.push(`  ${k}: ${v}`);
-            } else if (typeof v === "object" && v !== null) {
+            } else if (typeof v === 'object' && v !== null) {
               yamlLines.push(`  ${k}:`);
-              Object.entries(v as Record<string, unknown>).forEach(
-                ([subK, subV]) => {
-                  if (typeof subV === "string") {
-                    yamlLines.push(`    ${subK}: ${subV}`);
-                  } else {
-                    yamlLines.push(`    ${subK}: ${JSON.stringify(subV)}`);
-                  }
+              Object.entries(v as Record<string, unknown>).forEach(([subK, subV]) => {
+                if (typeof subV === 'string') {
+                  yamlLines.push(`    ${subK}: ${subV}`);
+                } else {
+                  yamlLines.push(`    ${subK}: ${JSON.stringify(subV)}`);
                 }
-              );
+              });
             } else {
               yamlLines.push(`  ${k}: ${JSON.stringify(v)}`);
             }
@@ -71,48 +75,45 @@ export const generateBlockYaml = (block: ServerBlock): string => {
   }
 
   //* ========================================
-  //* Job 블록 YAML 생성
+  //* Job 블록 YAML 생성 (평탄화된 config 기반)
   //* ========================================
-  else if (block.type === "job") {
-    //* config 내용만 사용하여 YAML 생성
-    const jobsConfig = block.config.jobs || {};
-    if (!jobsConfig || Object.keys(jobsConfig).length === 0) {
-      yamlLines.push("# Job 설정이 없습니다.");
+  else if (block.type === 'job') {
+    const jobConfig = (block.config || {}) as Record<string, unknown>;
+    if (!jobConfig || Object.keys(jobConfig).length === 0) {
+      yamlLines.push('# Job 설정이 없습니다.');
     } else {
-      Object.entries(jobsConfig).forEach(([jobName, jobConfig]) => {
-        yamlLines.push(`${jobName}:`);
-
-        Object.entries(jobConfig as Record<string, unknown>).forEach(
-          ([key, value]) => {
-            if (typeof value === "string") {
-              yamlLines.push(`  ${key}: ${value}`);
-            } else if (typeof value === "object" && value !== null) {
-              if (Array.isArray(value)) {
-                yamlLines.push(`  ${key}:`);
-                value.forEach((item: unknown) => {
-                  if (typeof item === "string") {
-                    yamlLines.push(`    - ${item}`);
-                  } else {
-                    yamlLines.push(`    - ${JSON.stringify(item)}`);
-                  }
-                });
-              } else {
-                yamlLines.push(`  ${key}:`);
-                Object.entries(value as Record<string, unknown>).forEach(
-                  ([k, v]) => {
-                    if (typeof v === "string") {
-                      yamlLines.push(`    ${k}: ${v}`);
-                    } else {
-                      yamlLines.push(`    ${k}: ${JSON.stringify(v)}`);
-                    }
-                  }
-                );
-              }
+      Object.entries(jobConfig).forEach(([key, value]) => {
+        if (
+          typeof value === 'string' ||
+          typeof value === 'number' ||
+          typeof value === 'boolean'
+        ) {
+          yamlLines.push(`${key}: ${value}`);
+        } else if (Array.isArray(value)) {
+          yamlLines.push(`${key}:`);
+          value.forEach((item) => {
+            if (typeof item === 'string') {
+              yamlLines.push(`  - ${item}`);
             } else {
-              yamlLines.push(`  ${key}: ${JSON.stringify(value)}`);
+              yamlLines.push(`  - ${JSON.stringify(item)}`);
             }
-          }
-        );
+          });
+        } else if (value && typeof value === 'object') {
+          yamlLines.push(`${key}:`);
+          Object.entries(value as Record<string, unknown>).forEach(([k, v]) => {
+            if (
+              typeof v === 'string' ||
+              typeof v === 'number' ||
+              typeof v === 'boolean'
+            ) {
+              yamlLines.push(`  ${k}: ${v}`);
+            } else {
+              yamlLines.push(`  ${k}: ${JSON.stringify(v)}`);
+            }
+          });
+        } else {
+          yamlLines.push(`${key}: ${JSON.stringify(value)}`);
+        }
       });
     }
   }
@@ -120,19 +121,19 @@ export const generateBlockYaml = (block: ServerBlock): string => {
   //* ========================================
   //* Step 블록 YAML 생성
   //* ========================================
-  else if (block.type === "step") {
+  else if (block.type === 'step') {
     //* config 내용만 사용하여 YAML 생성
     if (!block.config || Object.keys(block.config).length === 0) {
-      yamlLines.push("# Step 설정이 없습니다.");
+      yamlLines.push('# Step 설정이 없습니다.');
     } else {
       Object.entries(block.config).forEach(([key, value]) => {
-        if (typeof value === "string") {
+        if (typeof value === 'string') {
           yamlLines.push(`${key}: ${value}`);
-        } else if (typeof value === "object" && value !== null) {
+        } else if (typeof value === 'object' && value !== null) {
           if (Array.isArray(value)) {
             yamlLines.push(`${key}:`);
             value.forEach((item: unknown) => {
-              if (typeof item === "string") {
+              if (typeof item === 'string') {
                 yamlLines.push(`  - ${item}`);
               } else {
                 yamlLines.push(`  - ${JSON.stringify(item)}`);
@@ -140,15 +141,13 @@ export const generateBlockYaml = (block: ServerBlock): string => {
             });
           } else {
             yamlLines.push(`${key}:`);
-            Object.entries(value as Record<string, unknown>).forEach(
-              ([k, v]) => {
-                if (typeof v === "string") {
-                  yamlLines.push(`  ${k}: ${v}`);
-                } else {
-                  yamlLines.push(`  ${k}: ${JSON.stringify(v)}`);
-                }
+            Object.entries(value as Record<string, unknown>).forEach(([k, v]) => {
+              if (typeof v === 'string') {
+                yamlLines.push(`  ${k}: ${v}`);
+              } else {
+                yamlLines.push(`  ${k}: ${JSON.stringify(v)}`);
               }
-            );
+            });
           }
         } else {
           yamlLines.push(`${key}: ${JSON.stringify(value)}`);
@@ -157,7 +156,7 @@ export const generateBlockYaml = (block: ServerBlock): string => {
     }
   }
 
-  return yamlLines.join("\n");
+  return yamlLines.join('\n');
 };
 
 //* ========================================
@@ -171,93 +170,143 @@ export const generateFullYaml = (blocks: ServerBlock[]): string => {
 
   // blocks가 없으면 빈 문자열 반환
   if (!blocks || blocks.length === 0) {
-    return "# 워크플로우가 구성되지 않았습니다.";
+    return '# 워크플로우가 구성되지 않았습니다.';
   }
 
   //* ========================================
   //* 트리거 블록 처리
   //* ========================================
-  const triggerBlock = blocks.find((block) => block.type === "trigger");
+  const triggerBlock = blocks.find((block) => block.type === 'trigger');
   if (triggerBlock) {
     const triggerYaml = generateBlockYaml(triggerBlock);
     yamlLines.push(triggerYaml);
-    yamlLines.push("");
+    // 커스텀 메타 필드 (루트)
+    if (triggerBlock.name) {
+      yamlLines.push(`x_name: ${triggerBlock.name}`);
+    }
+    if (triggerBlock.description) {
+      yamlLines.push(`x_description: ${triggerBlock.description}`);
+    }
+    yamlLines.push('');
   }
 
   //* ========================================
   //* Job 블록들 처리
   //* ========================================
-  const jobBlocks = blocks.filter((block) => block.type === "job");
+  const jobBlocks = blocks.filter((block) => block.type === 'job');
   if (jobBlocks.length > 0) {
-    yamlLines.push("jobs:");
+    yamlLines.push('jobs:');
 
     jobBlocks.forEach((jobBlock, index) => {
-      const jobConfig = jobBlock.config?.jobs || {};
-      const jobName = Object.keys(jobConfig)[0];
-      const jobData = jobConfig[jobName as keyof typeof jobConfig] as Record<
-        string,
-        unknown
-      >;
+      const jobId = (jobBlock['job-name'] as string) || toJobId(jobBlock.name);
+      const jobData = (jobBlock.config || {}) as Record<string, unknown>;
 
-      if (jobName && jobData) {
-        yamlLines.push(`${jobName}:`);
+      if (jobId && jobData) {
+        yamlLines.push(`${jobId}:`);
 
         //* runs-on 설정
-        if (jobData["runs-on"]) {
-          yamlLines.push(`  runs-on: ${jobData["runs-on"]}`);
+        if (jobData['runs-on']) {
+          yamlLines.push(`  runs-on: ${jobData['runs-on']}`);
         }
 
         //* needs 설정
-        if (
-          jobData.needs &&
-          Array.isArray(jobData.needs) &&
-          jobData.needs.length > 0
-        ) {
-          yamlLines.push("  needs:");
+        if (jobData.needs && Array.isArray(jobData.needs) && jobData.needs.length > 0) {
+          yamlLines.push('  needs:');
           jobData.needs.forEach((need: unknown) => {
-            if (typeof need === "string") {
+            if (typeof need === 'string') {
               yamlLines.push(`    - ${need}`);
             }
           });
         }
 
         //* if 조건 설정
-        if (jobData.if && typeof jobData.if === "string") {
+        if (jobData.if && typeof jobData.if === 'string') {
           yamlLines.push(`  if: ${jobData.if}`);
         }
 
         //* timeout 설정
-        if (jobData.timeout && typeof jobData.timeout === "number") {
+        if (jobData.timeout && typeof jobData.timeout === 'number') {
           yamlLines.push(`  timeout-minutes: ${jobData.timeout}`);
+        }
+
+        //* 커스텀 메타 필드 (Job)
+        if (jobBlock.name) {
+          yamlLines.push(`  x_name: ${jobBlock.name}`);
+        }
+        if (jobBlock.description) {
+          yamlLines.push(`  x_description: ${jobBlock.description}`);
         }
 
         //* ========================================
         //* 해당 Job의 Step들 처리 (job-name으로 연결)
         //* ========================================
-        // job-name을 사용하여 step들을 찾음
-        const jobNameForSteps = jobBlock["job-name"] || jobName;
+        // job-id를 사용하여 step들을 찾음
+        const jobNameForSteps = jobId;
         const stepBlocks = blocks.filter(
-          (block) =>
-            block.type === "step" && block["job-name"] === jobNameForSteps
+          (block) => block.type === 'step' && block['job-name'] === jobNameForSteps,
         );
 
         if (stepBlocks.length > 0) {
-          yamlLines.push("  steps:");
+          yamlLines.push('  steps:');
           stepBlocks.forEach((stepBlock) => {
-            const stepYaml = generateBlockYaml(stepBlock);
-            const stepLines = stepYaml.split("\n");
-            stepLines.forEach((line) => {
-              if (line.trim()) {
-                yamlLines.push(`    ${line}`);
+            const stepConfig = (stepBlock.config || {}) as Record<string, unknown>;
+            const stepName = (stepConfig.name as string) || stepBlock.name || '';
+            yamlLines.push(`    - name: ${stepName}`);
+            // 커스텀 메타 필드 (Step)
+            if (stepBlock.name) {
+              yamlLines.push(`      x_name: ${stepBlock.name}`);
+            }
+            if (stepBlock.description) {
+              yamlLines.push(`      x_description: ${stepBlock.description}`);
+            }
+            if (stepBlock.domain) {
+              yamlLines.push(`      x_domain: ${stepBlock.domain}`);
+            }
+            if (Array.isArray(stepBlock.task) && stepBlock.task.length > 0) {
+              yamlLines.push('      x_task:');
+              stepBlock.task.forEach((t) => yamlLines.push(`        - ${t}`));
+            }
+
+            // 나머지 config를 출력 (name 중복 제외)
+            Object.entries(stepConfig).forEach(([k, v]) => {
+              if (k === 'name') return;
+              if (
+                typeof v === 'string' ||
+                typeof v === 'number' ||
+                typeof v === 'boolean'
+              ) {
+                yamlLines.push(`      ${k}: ${v}`);
+              } else if (Array.isArray(v)) {
+                yamlLines.push(`      ${k}:`);
+                (v as unknown[]).forEach((item) => {
+                  if (typeof item === 'string') {
+                    yamlLines.push(`        - ${item}`);
+                  } else {
+                    yamlLines.push(`        - ${JSON.stringify(item)}`);
+                  }
+                });
+              } else if (v && typeof v === 'object') {
+                yamlLines.push(`      ${k}:`);
+                Object.entries(v as Record<string, unknown>).forEach(([sk, sv]) => {
+                  if (
+                    typeof sv === 'string' ||
+                    typeof sv === 'number' ||
+                    typeof sv === 'boolean'
+                  ) {
+                    yamlLines.push(`        ${sk}: ${sv}`);
+                  } else {
+                    yamlLines.push(`        ${sk}: ${JSON.stringify(sv)}`);
+                  }
+                });
               }
             });
           });
         }
 
-        //* 추가 Job 설정들
+        //* 추가 Job 설정들 (이미 처리한 키 제외)
         Object.entries(jobData).forEach(([key, value]) => {
-          if (!["runs-on", "needs", "if", "timeout", "steps"].includes(key)) {
-            if (typeof value === "string") {
+          if (!['runs-on', 'needs', 'if', 'timeout', 'steps'].includes(key)) {
+            if (typeof value === 'string') {
               yamlLines.push(`  ${key}: ${value}`);
             } else {
               yamlLines.push(`  ${key}: ${JSON.stringify(value)}`);
@@ -266,11 +315,11 @@ export const generateFullYaml = (blocks: ServerBlock[]): string => {
         });
 
         if (index < jobBlocks.length - 1) {
-          yamlLines.push("");
+          yamlLines.push('');
         }
       }
     });
   }
 
-  return yamlLines.join("\n");
+  return yamlLines.join('\n');
 };

--- a/src/app/github-actions-flow/utils/yamlUtils.ts
+++ b/src/app/github-actions-flow/utils/yamlUtils.ts
@@ -1,0 +1,42 @@
+// * YAML 파싱/포맷 공통 유틸
+import YAML from 'yaml';
+
+export type YamlParseResult = {
+  success: boolean;
+  data?: Record<string, unknown>;
+  error?: string;
+};
+
+export const parseYamlToConfigStrict = (yamlText: string): YamlParseResult => {
+  try {
+    // YAML -> JS 객체
+    const parsed = YAML.parse(yamlText ?? '');
+    if (parsed === null || parsed === undefined) {
+      return { success: true, data: {} };
+    }
+    if (typeof parsed !== 'object') {
+      return { success: false, error: 'YAML 최상위 구조는 객체여야 합니다.' };
+    }
+    return { success: true, data: parsed as Record<string, unknown> };
+  } catch (err: any) {
+    return { success: false, error: err?.message || 'YAML 파싱 오류가 발생했습니다.' };
+  }
+};
+
+export const formatYaml = (yamlText: string): string => {
+  const result = parseYamlToConfigStrict(yamlText);
+  if (!result.success || !result.data) return yamlText;
+  try {
+    return YAML.stringify(result.data, { indent: 2 });
+  } catch {
+    return yamlText;
+  }
+};
+
+export const stringifyYaml = (data: unknown): string => {
+  try {
+    return YAML.stringify(data ?? {}, { indent: 2 });
+  } catch {
+    return '';
+  }
+};

--- a/src/app/presets/page.tsx
+++ b/src/app/presets/page.tsx
@@ -76,7 +76,11 @@ export default function PresetsPage() {
         name: block.name,
         description: block.description,
         type: block.type,
-        content: block.content,
+        // 백엔드 표준인 config 필드 우선 사용, 없으면 content로 폴백
+        config: block.config ?? block.content,
+        jobName: block.jobName,
+        domain: block.domain,
+        task: block.task,
       };
 
       await navigator.clipboard.writeText(JSON.stringify(blockData, null, 2));

--- a/src/components/features/WorkflowManager.tsx
+++ b/src/components/features/WorkflowManager.tsx
@@ -1,41 +1,38 @@
-"use client";
+'use client';
 
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
-import { useWorkflows, usePipeline, useUpdatePipeline } from "@/api/hooks";
-import { WorkflowItem } from "@/api/githubClient";
-import { useRepository } from "@/contexts/RepositoryContext";
-import { GithubTokenDialog } from "./GithubTokenDialog";
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+import { useWorkflows, usePipeline, useUpdatePipeline } from '@/api/hooks';
+import { WorkflowItem } from '@/api';
+import { useRepository } from '@/contexts/RepositoryContext';
+import { GithubTokenDialog } from './GithubTokenDialog';
 
 export default function WorkflowManager() {
   const { owner, repo, isConfigured } = useRepository();
-  const [selectedWorkflow, setSelectedWorkflow] = useState<WorkflowItem | null>(
-    null
-  );
+  const [selectedWorkflow, setSelectedWorkflow] = useState<WorkflowItem | null>(null);
 
   // * React Query 훅 사용
   const {
     data: workflowsData,
     isLoading: workflowsLoading,
     error: workflowsError,
-  } = useWorkflows(owner || "", repo || "");
+  } = useWorkflows(owner || '', repo || '');
   const {
     data: pipelineData,
     isLoading: pipelineLoading,
     error: pipelineError,
   } = usePipeline(
-    selectedWorkflow?.fileName || selectedWorkflow?.name || "",
-    owner || "",
-    repo || ""
+    selectedWorkflow?.fileName || selectedWorkflow?.name || '',
+    owner || '',
+    repo || '',
   );
   const updatePipelineMutation = useUpdatePipeline();
 
   const workflows = workflowsData?.data?.workflows || [];
-  const loading =
-    workflowsLoading || pipelineLoading || updatePipelineMutation.isPending;
+  const loading = workflowsLoading || pipelineLoading || updatePipelineMutation.isPending;
   const error = workflowsError || pipelineError || updatePipelineMutation.error;
 
   // * 워크플로우 선택
@@ -53,11 +50,11 @@ export default function WorkflowManager() {
         repo,
         workflowName: pipelineData.data.workflowName,
         inputJson: pipelineData.data.originalJson,
-        description: "",
+        description: '',
       });
-      alert("파이프라인이 성공적으로 업데이트되었습니다.");
+      alert('파이프라인이 성공적으로 업데이트되었습니다.');
     } catch (err) {
-      console.error("파이프라인 업데이트 실패:", err);
+      console.error('파이프라인 업데이트 실패:', err);
     }
   };
 
@@ -98,9 +95,7 @@ export default function WorkflowManager() {
               <p className="mb-4">위의 설정을 완료해주세요.</p>
             </div>
           )}
-          {isConfigured && loading && (
-            <div className="text-center py-4">로딩 중...</div>
-          )}
+          {isConfigured && loading && <div className="text-center py-4">로딩 중...</div>}
           {isConfigured && error && (
             <div className="text-red-600 text-center py-4">
               <div className="font-semibold mb-2">오류가 발생했습니다:</div>
@@ -113,9 +108,7 @@ export default function WorkflowManager() {
             </div>
           )}
           {isConfigured && !loading && !error && workflows.length === 0 && (
-            <div className="text-center py-4 text-gray-500">
-              워크플로우가 없습니다.
-            </div>
+            <div className="text-center py-4 text-gray-500">워크플로우가 없습니다.</div>
           )}
           {isConfigured && !loading && !error && workflows.length > 0 && (
             <div className="grid gap-4">
@@ -124,8 +117,8 @@ export default function WorkflowManager() {
                   key={workflow.id}
                   className={`cursor-pointer transition-colors ${
                     selectedWorkflow?.id === workflow.id
-                      ? "border-blue-500 bg-blue-50"
-                      : "hover:border-gray-300"
+                      ? 'border-blue-500 bg-blue-50'
+                      : 'hover:border-gray-300'
                   }`}
                   onClick={() => handleWorkflowSelect(workflow)}
                 >
@@ -137,11 +130,7 @@ export default function WorkflowManager() {
                       </div>
                       <div className="flex items-center gap-2">
                         <Badge
-                          variant={
-                            workflow.state === "active"
-                              ? "default"
-                              : "secondary"
-                          }
+                          variant={workflow.state === 'active' ? 'default' : 'secondary'}
                         >
                           {workflow.state}
                         </Badge>
@@ -168,27 +157,24 @@ export default function WorkflowManager() {
             <div className="space-y-4">
               <div className="grid grid-cols-2 gap-4 text-sm">
                 <div>
-                  <span className="font-medium">파일 경로:</span>{" "}
-                  {selectedWorkflow.path}
+                  <span className="font-medium">파일 경로:</span> {selectedWorkflow.path}
                 </div>
                 <div>
-                  <span className="font-medium">상태:</span>{" "}
+                  <span className="font-medium">상태:</span>{' '}
                   <Badge
                     variant={
-                      selectedWorkflow.state === "active"
-                        ? "default"
-                        : "secondary"
+                      selectedWorkflow.state === 'active' ? 'default' : 'secondary'
                     }
                   >
                     {selectedWorkflow.state}
                   </Badge>
                 </div>
                 <div>
-                  <span className="font-medium">생성일:</span>{" "}
+                  <span className="font-medium">생성일:</span>{' '}
                   {new Date(selectedWorkflow.createdAt).toLocaleDateString()}
                 </div>
                 <div>
-                  <span className="font-medium">수정일:</span>{" "}
+                  <span className="font-medium">수정일:</span>{' '}
                   {new Date(selectedWorkflow.updatedAt).toLocaleDateString()}
                 </div>
               </div>
@@ -197,9 +183,7 @@ export default function WorkflowManager() {
 
               {/* 파이프라인 데이터 */}
               {pipelineLoading && (
-                <div className="text-center py-4">
-                  파이프라인 데이터 로딩 중...
-                </div>
+                <div className="text-center py-4">파이프라인 데이터 로딩 중...</div>
               )}
               {pipelineError && (
                 <div className="text-red-600 text-center py-4">
@@ -212,11 +196,7 @@ export default function WorkflowManager() {
                     <h4 className="font-semibold mb-2">파이프라인 구성</h4>
                     <div className="bg-gray-100 p-4 rounded-lg">
                       <pre className="text-sm overflow-x-auto">
-                        {JSON.stringify(
-                          pipelineData.data.originalJson,
-                          null,
-                          2
-                        )}
+                        {JSON.stringify(pipelineData.data.originalJson, null, 2)}
                       </pre>
                     </div>
                   </div>
@@ -236,8 +216,8 @@ export default function WorkflowManager() {
                     className="w-full"
                   >
                     {updatePipelineMutation.isPending
-                      ? "업데이트 중..."
-                      : "파이프라인 업데이트"}
+                      ? '업데이트 중...'
+                      : '파이프라인 업데이트'}
                   </Button>
                 </div>
               )}

--- a/src/config/apiConfig.ts
+++ b/src/config/apiConfig.ts
@@ -1,0 +1,86 @@
+//* ========================================
+//* API 설정
+//* ========================================
+
+//* 실제 API 사용 여부 설정
+export const API_CONFIG = {
+  //* 실제 백엔드 API 사용 여부
+  //* - production 환경에서는 자동으로 true
+  //* - development 환경에서는 환경변수로 제어
+  USE_REAL_API:
+    process.env.NODE_ENV === 'production' ||
+    process.env.NEXT_PUBLIC_USE_REAL_API === 'true',
+
+  //* 백엔드 API 기본 URL
+  BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080',
+
+  //* API 타임아웃 (ms)
+  TIMEOUT: 10000,
+
+  //* 재시도 횟수
+  RETRY_COUNT: 3,
+
+  //* 재시도 간격 (ms)
+  RETRY_DELAY: 1000,
+};
+
+//* API 엔드포인트 정의
+export const API_ENDPOINTS = {
+  //* 파이프라인 관련
+  PIPELINES: {
+    CREATE: '/api/pipelines',
+    GET: (ymlFileName: string, owner: string, repo: string) =>
+      `/api/pipelines/${ymlFileName}?owner=${owner}&repo=${repo}`,
+    UPDATE: '/api/pipelines',
+    DELETE: (ymlFileName: string, owner: string, repo: string) =>
+      `/api/pipelines/${ymlFileName}?owner=${owner}&repo=${repo}`,
+  },
+
+  //* 프리셋 관련
+  PRESETS: {
+    BLOCKS: '/api/presets/blocks',
+    PIPELINES: '/api/presets/pipelines',
+  },
+
+  //* GitHub 관련
+  GITHUB: {
+    WORKFLOWS: (owner: string, repo: string) =>
+      `/api/github/workflows?owner=${owner}&repo=${repo}`,
+    WORKFLOW_DETAIL: (workflowId: string, owner: string, repo: string) =>
+      `/api/github/workflows/${workflowId}?owner=${owner}&repo=${repo}`,
+    WORKFLOW_RUNS: (owner: string, repo: string) =>
+      `/api/github/workflow-runs?owner=${owner}&repo=${repo}`,
+    SECRETS: (owner: string, repo: string) =>
+      `/api/github/repos/secrets?owner=${owner}&repo=${repo}`,
+  },
+};
+
+//* 에러 메시지 정의
+export const API_ERROR_MESSAGES = {
+  NETWORK_ERROR: '네트워크 연결에 실패했습니다.',
+  UNAUTHORIZED: '인증이 필요합니다.',
+  FORBIDDEN: '접근 권한이 없습니다.',
+  NOT_FOUND: '요청한 리소스를 찾을 수 없습니다.',
+  SERVER_ERROR: '서버 오류가 발생했습니다.',
+  TIMEOUT: '요청 시간이 초과되었습니다.',
+  UNKNOWN: '알 수 없는 오류가 발생했습니다.',
+};
+
+//* HTTP 상태 코드별 에러 메시지 매핑
+export const getErrorMessage = (status: number): string => {
+  switch (status) {
+    case 401:
+      return API_ERROR_MESSAGES.UNAUTHORIZED;
+    case 403:
+      return API_ERROR_MESSAGES.FORBIDDEN;
+    case 404:
+      return API_ERROR_MESSAGES.NOT_FOUND;
+    case 500:
+      return API_ERROR_MESSAGES.SERVER_ERROR;
+    case 408:
+    case 504:
+      return API_ERROR_MESSAGES.TIMEOUT;
+    default:
+      return API_ERROR_MESSAGES.UNKNOWN;
+  }
+};

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,16 +1,18 @@
 // * 브랜드 관련
-export {
-  BRAND,
-  BRAND_NAME,
-  BRAND_DESCRIPTION,
-  BRAND_LOGO,
-} from "./appConstants";
+export { BRAND, BRAND_NAME, BRAND_DESCRIPTION, BRAND_LOGO } from './appConstants';
 
 // * 홈 페이지 관련
-export { HOME } from "./appConstants";
+export { HOME } from './appConstants';
 
 // * 라우트 관련
-export { ROUTES, ROUTE_URLS, ROUTE_LABELS, ROUTE_LIST } from "./appConstants";
+export { ROUTES, ROUTE_URLS, ROUTE_LABELS, ROUTE_LIST } from './appConstants';
 
 // * 파일 관련
-export { FILES, CHANGED_FILES, FILE_STATES, FILE_LIST } from "./appConstants";
+export { FILES, CHANGED_FILES, FILE_STATES, FILE_LIST } from './appConstants';
+// * API 설정 관련
+export {
+  API_CONFIG,
+  API_ENDPOINTS,
+  API_ERROR_MESSAGES,
+  getErrorMessage,
+} from './apiConfig';

--- a/src/lib/githubActions.ts
+++ b/src/lib/githubActions.ts
@@ -4,10 +4,10 @@ import {
   workflowAPI,
   PipelineRequest,
   GithubSecretRequest,
-} from "@/api/githubClient";
-import { AxiosError } from "axios";
-import { getCookie } from "@/lib/cookieUtils";
-import { STORAGES } from "@/config/appConstants";
+} from '@/api';
+import { AxiosError } from 'axios';
+import { getCookie } from '@/lib/cookieUtils';
+import { STORAGES } from '@/config/appConstants';
 
 // * 파이프라인 관리 유틸리티
 export const pipelineUtils = {
@@ -17,7 +17,7 @@ export const pipelineUtils = {
       const response = await pipelineAPI.create(data);
       return { success: true, data: response.data };
     } catch (error) {
-      console.error("파이프라인 생성 실패:", error);
+      console.error('파이프라인 생성 실패:', error);
       return { success: false, error };
     }
   },
@@ -28,7 +28,7 @@ export const pipelineUtils = {
       const response = await pipelineAPI.get(ymlFileName, owner, repo);
       return { success: true, data: response.data };
     } catch (error) {
-      console.error("파이프라인 조회 실패:", error);
+      console.error('파이프라인 조회 실패:', error);
       return { success: false, error };
     }
   },
@@ -39,7 +39,7 @@ export const pipelineUtils = {
       const response = await pipelineAPI.update(data);
       return { success: true, data: response.data };
     } catch (error) {
-      console.error("파이프라인 업데이트 실패:", error);
+      console.error('파이프라인 업데이트 실패:', error);
       return { success: false, error };
     }
   },
@@ -50,7 +50,7 @@ export const pipelineUtils = {
       await pipelineAPI.delete(ymlFileName, owner, repo);
       return { success: true };
     } catch (error) {
-      console.error("파이프라인 삭제 실패:", error);
+      console.error('파이프라인 삭제 실패:', error);
       return { success: false, error };
     }
   },
@@ -64,7 +64,7 @@ export const secretsUtils = {
       const response = await secretsAPI.getList(owner, repo);
       return { success: true, data: response.data };
     } catch (error) {
-      console.error("Secrets 목록 조회 실패:", error);
+      console.error('Secrets 목록 조회 실패:', error);
       return { success: false, error };
     }
   },
@@ -74,14 +74,14 @@ export const secretsUtils = {
     owner: string,
     repo: string,
     secretName: string,
-    value: string
+    value: string,
   ) => {
     try {
       const data: GithubSecretRequest = { value };
       await secretsAPI.createOrUpdate(owner, repo, secretName, data);
       return { success: true };
     } catch (error) {
-      console.error("Secret 생성/수정 실패:", error);
+      console.error('Secret 생성/수정 실패:', error);
       return { success: false, error };
     }
   },
@@ -92,7 +92,7 @@ export const secretsUtils = {
       const response = await secretsAPI.getPublicKey(owner, repo);
       return { success: true, data: response.data };
     } catch (error) {
-      console.error("퍼블릭 키 조회 실패:", error);
+      console.error('퍼블릭 키 조회 실패:', error);
       return { success: false, error };
     }
   },
@@ -103,7 +103,7 @@ export const secretsUtils = {
       await secretsAPI.delete(owner, repo, secretName);
       return { success: true };
     } catch (error) {
-      console.error("Secret 삭제 실패:", error);
+      console.error('Secret 삭제 실패:', error);
       return { success: false, error };
     }
   },
@@ -114,39 +114,33 @@ export const workflowUtils = {
   // * Workflow 목록 조회
   getWorkflowsList: async (owner: string, repo: string) => {
     try {
-      console.log("API 호출 시작:", { owner, repo });
+      console.log('API 호출 시작:', { owner, repo });
 
       // * GitHub 토큰 확인
       const savedGithubToken = getCookie(STORAGES.GITHUB_TOKEN);
       if (!savedGithubToken) {
-        console.error("GitHub 토큰이 설정되지 않았습니다.");
+        console.error('GitHub 토큰이 설정되지 않았습니다.');
         return {
           success: false,
           error: new Error(
-            "GitHub Personal Access Token이 설정되지 않았습니다. 설정에서 토큰을 입력해주세요."
+            'GitHub Personal Access Token이 설정되지 않았습니다. 설정에서 토큰을 입력해주세요.',
           ),
         };
       }
 
-      console.log(
-        "GitHub 토큰 확인됨:",
-        savedGithubToken.substring(0, 10) + "..."
-      );
+      console.log('GitHub 토큰 확인됨:', savedGithubToken.substring(0, 10) + '...');
 
       const response = await workflowAPI.getList(owner, repo);
-      console.log("API 응답 성공:", response.data);
+      console.log('API 응답 성공:', response.data);
       return { success: true, data: response.data };
     } catch (error) {
-      console.error("Workflow 목록 조회 실패:", error);
-      console.error("오류 상세 정보:", {
-        message: error instanceof Error ? error.message : "Unknown error",
+      console.error('Workflow 목록 조회 실패:', error);
+      console.error('오류 상세 정보:', {
+        message: error instanceof Error ? error.message : 'Unknown error',
         code: error instanceof AxiosError ? error.code : undefined,
-        response:
-          error instanceof AxiosError ? error.response?.data : undefined,
-        status:
-          error instanceof AxiosError ? error.response?.status : undefined,
-        headers:
-          error instanceof AxiosError ? error.response?.headers : undefined,
+        response: error instanceof AxiosError ? error.response?.data : undefined,
+        status: error instanceof AxiosError ? error.response?.status : undefined,
+        headers: error instanceof AxiosError ? error.response?.headers : undefined,
       });
 
       return { success: false, error };
@@ -154,16 +148,12 @@ export const workflowUtils = {
   },
 
   // * Workflow 상세 정보 조회
-  getWorkflowDetail: async (
-    workflowId: string,
-    owner: string,
-    repo: string
-  ) => {
+  getWorkflowDetail: async (workflowId: string, owner: string, repo: string) => {
     try {
       const response = await workflowAPI.getDetail(workflowId, owner, repo);
       return { success: true, data: response.data };
     } catch (error) {
-      console.error("Workflow 상세 정보 조회 실패:", error);
+      console.error('Workflow 상세 정보 조회 실패:', error);
       return { success: false, error };
     }
   },
@@ -174,7 +164,7 @@ export const workflowUtils = {
       const response = await workflowAPI.getRuns(owner, repo);
       return { success: true, data: response.data };
     } catch (error) {
-      console.error("Workflow 실행 목록 조회 실패:", error);
+      console.error('Workflow 실행 목록 조회 실패:', error);
       return { success: false, error };
     }
   },
@@ -185,7 +175,7 @@ export const workflowUtils = {
       const response = await workflowAPI.getRunDetail(owner, repo, runId);
       return { success: true, data: response.data };
     } catch (error) {
-      console.error("Workflow 실행 상세 정보 조회 실패:", error);
+      console.error('Workflow 실행 상세 정보 조회 실패:', error);
       return { success: false, error };
     }
   },
@@ -196,7 +186,7 @@ export const workflowUtils = {
       const response = await workflowAPI.getRunLogs(owner, repo, runId);
       return { success: true, data: response.data };
     } catch (error) {
-      console.error("Workflow 실행 로그 조회 실패:", error);
+      console.error('Workflow 실행 로그 조회 실패:', error);
       return { success: false, error };
     }
   },
@@ -207,7 +197,7 @@ export const workflowUtils = {
       const response = await workflowAPI.getRunJobs(owner, repo, runId);
       return { success: true, data: response.data };
     } catch (error) {
-      console.error("Workflow 실행 Job 조회 실패:", error);
+      console.error('Workflow 실행 Job 조회 실패:', error);
       return { success: false, error };
     }
   },
@@ -218,7 +208,7 @@ export const workflowUtils = {
       const response = await workflowAPI.getJobDetail(owner, repo, jobId);
       return { success: true, data: response.data };
     } catch (error) {
-      console.error("Job 상세 정보 조회 실패:", error);
+      console.error('Job 상세 정보 조회 실패:', error);
       return { success: false, error };
     }
   },
@@ -228,18 +218,13 @@ export const workflowUtils = {
     owner: string,
     repo: string,
     ymlFileName: string,
-    ref: string
+    ref: string,
   ) => {
     try {
-      const response = await workflowAPI.dispatch(
-        owner,
-        repo,
-        ymlFileName,
-        ref
-      );
+      const response = await workflowAPI.dispatch(owner, repo, ymlFileName, ref);
       return { success: true, data: response.data };
     } catch (error) {
-      console.error("Workflow 수동 실행 실패:", error);
+      console.error('Workflow 수동 실행 실패:', error);
       return { success: false, error };
     }
   },
@@ -250,7 +235,7 @@ export const workflowUtils = {
       const response = await workflowAPI.cancelRun(owner, repo, runId);
       return { success: true, data: response.data };
     } catch (error) {
-      console.error("Workflow 실행 취소 실패:", error);
+      console.error('Workflow 실행 취소 실패:', error);
       return { success: false, error };
     }
   },


### PR DESCRIPTION
* feat(api): Preset API/훅 추가 및 블록 엔드포인트/타입 정합화 (#17)

- Presets API/훅 추가
- 블록 엔드포인트를 /api/presets/blocks로 정합화
- BlockResponse 타입을 백엔드 스키마에 맞게 정리

* feat(editor): DragDropSidebar에서 Preset 실제 API 사용으로 전환 (#17)

- DragDropSidebar가 usePresetBlocks/usePresetPipelines로 실제 API 사용
- 응답을 탭별 그룹으로 매핑해 기존 UI 유지

* fix(presets): BlockResponse 호환 위해 config 우선 복사, content 폴백 (#17)
- 백엔드 표준 필드(config) 우선 복사, content는 폴백

* feat(config): apiConfig 추가 및 .env 문서화; mockData 실/목 전환 토글 연동 (#17)

- apiConfig 추가 및 .env 문서화
- mockData에서 실/목 전환 가능하도록 토글 반영

* refactor(api): API 구성/엔드포인트/불필요 의존 제거 (#17)

* feat(node_edit): 노드 패널 UX 개선, YAML 편집 개선 및 의존성 추가 (#17)

- 탭 구조 단순화(설정/YAML), 트리 탭 제거 및 컨트롤/설정 통합

- 엄격 파싱/포맷 도입(yaml 패키지), 블록/전체 전환, 편집/포맷/저장 UX 정리

- 노드 편집 패널 사용성 개선

* feat(actions-yaml): YAML 생성 로직 개선 (#17)

- Job: 평탄화 config 반영 및 job-id 기반 step 매핑

- Trigger/Job/Step 커스텀 메타 필드(x_name, x_description, x_domain, x_task) 출력

- Steps: name 우선 표기 후 나머지 config 병합 출력으로 가독성 개선